### PR TITLE
Add Condition for Schemaless Record

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
     apacheHttpClientVersion = '4.5.6'
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
-    googleCloudVersion = '0.47.0-alpha'
+    googleCloudVersion = '1.79.0'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -195,9 +195,10 @@ project(':kcbq-connector') {
         compile (
                 project(':kcbq-api'),
 
-                "com.google.cloud:google-cloud:$googleCloudVersion",
+                "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
+                "com.google.cloud:google-cloud-storage:$googleCloudVersion",
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
-                "com.google.code.gson:gson:$googleCloudVersion",
+                "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
@@ -248,7 +249,7 @@ project('kcbq-api') {
 
     dependencies {
         compile (
-                "com.google.cloud:google-cloud:$googleCloudVersion",
+                "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion"
         )
     }
@@ -316,7 +317,6 @@ project('kcbq-confluent') {
         compile (
                 project(':kcbq-api'),
 
-                "com.google.cloud:google-cloud:$googleCloudVersion",
                 "io.confluent:kafka-connect-avro-converter:$ioConfluentVersion",
                 "io.confluent:kafka-schema-registry-client:$ioConfluentVersion",
                 "org.apache.avro:avro:$avroVersion",

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
-    commonsVersion = '3.9'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -201,7 +200,6 @@ project(':kcbq-connector') {
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
-                "org.apache.commons:commons-lang3:$commonsVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
+    commonsVersion = '3.9'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -200,6 +201,7 @@ project(':kcbq-connector') {
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
+                "org.apache.commons:commons-lang3:$commonsVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -123,19 +123,8 @@ public class BigQuerySinkTask extends SinkTask {
     } catch (InterruptedException err) {
       throw new ConnectException("Interrupted while waiting for write tasks to complete.", err);
     }
-    updateOffsets(offsets);
 
     topicPartitionManager.resumeAll();
-  }
-
-  /**
-   * This really doesn't do much and I'm not totally clear on whether or not I need it.
-   * But, in the interest of maintaining old functionality, here we are.
-   */
-  private void updateOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    for (Map.Entry<TopicPartition, OffsetAndMetadata> offsetEntry : offsets.entrySet()) {
-      context.offset(offsetEntry.getKey(), offsetEntry.getValue().offset());
-    }
   }
 
   private PartitionedTableId getRecordTable(SinkRecord record) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -176,6 +176,10 @@ public class BigQuerySinkTask extends SinkTask {
           TableWriterBuilder tableWriterBuilder;
           if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String gcsBlobName = record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
+            String gcsFolderName = config.getString(config.GCS_FOLDER_NAME_CONFIG);
+            if (gcsFolderName != null && !"".equals(gcsFolderName)) {
+              gcsBlobName = gcsFolderName + "/" + gcsBlobName;
+            }
             tableWriterBuilder = new GCSBatchTableWriter.Builder(
                 gcsToBQWriter,
                 table.getBaseTableId(),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -319,7 +319,7 @@ public class BigQuerySinkTask extends SinkTask {
         try {
           logger.info("Attempting to shut down GCS Load Executor.");
           gcsLoadExecutor.shutdown();
-          executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
+          gcsLoadExecutor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
           logger.warn("Could not shut down GCS Load Executor within {}s.",
                       EXECUTOR_SHUTDOWN_TIMEOUT_SEC);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -84,6 +84,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "The name of the bucket in which gcs blobs used to batch load to BigQuery "
       + "should be located. Only relevant if enableBatchLoad is configured.";
 
+  public static final String GCS_FOLDER_NAME_CONFIG =                     "gcsFolderName";
+  private static final ConfigDef.Type GCS_FOLDER_NAME_TYPE =              ConfigDef.Type.STRING;
+  private static final Object GCS_FOLDER_NAME_DEFAULT =                   "";
+  private static final ConfigDef.Importance GCS_FOLDER_NAME_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
+  private static final String GCS_FOLDER_NAME_DOC =
+          "The name of the folder under the bucket in which gcs blobs used to batch load to BigQuery "
+                  + "should be located. Only relevant if enableBatchLoad is configured.";
+
   public static final String TOPICS_TO_TABLES_CONFIG =                     "topicsToTables";
   private static final ConfigDef.Type TOPICS_TO_TABLES_TYPE =              ConfigDef.Type.LIST;
   private static final ConfigDef.Importance TOPICS_TO_TABLES_IMPORTANCE =
@@ -195,6 +203,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             GCS_BUCKET_NAME_DEFAULT,
             GCS_BUCKET_NAME_IMPORTANCE,
             GCS_BUCKET_NAME_DOC
+        ).define(
+            GCS_FOLDER_NAME_CONFIG,
+            GCS_FOLDER_NAME_TYPE,
+            GCS_FOLDER_NAME_DEFAULT,
+            GCS_FOLDER_NAME_IMPORTANCE,
+            GCS_FOLDER_NAME_DOC
         ).define(
             TOPICS_TO_TABLES_CONFIG,
             TOPICS_TO_TABLES_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.ClassUtils;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.nio.ByteBuffer;
@@ -83,6 +82,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   }
 
   private Object validateSchemalessRecord(Object value) {
+    if (value instanceof Double) {
+      return convertDouble((Double) value);
+    }
     if (ClassUtils.isPrimitiveWrapper(value.getClass()) || value instanceof String) {
       return value;
     }
@@ -101,8 +103,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
                 Collectors.toMap(
                         entry -> {
                           if (!(entry.getKey() instanceof String)) {
-                            throw new DataException(
-                                    "Map objects in absence of schema needs to have string value keys.");
+                            throw new ConversionConnectException(
+                                    "Map objects in absence of schema needs to have string value keys. " +
+                                    "Failed to convert record to bigQuery format.");
                           }
                           return entry.getKey();
                         },

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -73,6 +73,14 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
    */
   public Map<String, Object> convertRecord(SinkRecord kafkaConnectRecord) {
     Schema kafkaConnectSchema = kafkaConnectRecord.valueSchema();
+    Object kafkaConnectValue = kafkaConnectRecord.value();
+    if (kafkaConnectSchema == null) {
+      if (kafkaConnectValue instanceof Map) {
+        return (Map) kafkaConnectRecord;
+      }
+      throw new ConversionConnectException("Only Map objects supported in absence of schema for " +
+              "record conversion to BigQuery format.");
+    }
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new
           ConversionConnectException("Top-level Kafka Connect schema must be of type 'struct'");

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -74,8 +74,10 @@ public class GCSBatchTableWriter implements Runnable {
   public void run() {
     try {
       writer.writeRows(rows, tableId, bucketName, blobName);
-    } catch (ConnectException | InterruptedException ex) {
-      throw new ConnectException("Thread interrupted while batch writing to BigQuery.", ex);
+    } catch (ConnectException ex) {
+      throw new ConnectException("Failed to write rows to GCS", ex);
+    } catch (InterruptedException ex) {
+      throw new ConnectException("Thread interrupted while batch writing", ex);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -25,6 +25,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.gson.Gson;
 
 import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
@@ -107,24 +108,28 @@ public class GCSToBQWriter {
           String.format("Table with TableId %s does not exist.", tableId.getTable()));
     }
 
-    int retryCount = 0;
-    boolean exceptionsOccurred;
-    do {
-      if (retryCount > 0) {
+    int attemptCount = 0;
+    boolean success = false;
+    while (!success && (attemptCount <= retries)) {
+      if (attemptCount > 0) {
         waitRandomTime();
       }
-      exceptionsOccurred = false;
-      // Perform GCS Upload and BQ Transfer
+      // Perform GCS Upload
       try {
         uploadRowsToGcs(rows, blobInfo);
-      } catch (ConnectException ce) {
-        exceptionsOccurred = true;
+        success = true;
+      } catch (StorageException se) {
         logger.warn("Exceptions occurred for table {}, attempting retry", tableId.getTable());
       }
-      retryCount++;
-    } while (exceptionsOccurred && (retryCount < retries));
+      attemptCount++;
+    }
 
-    logger.info("Batch loaded {} rows", rows.size());
+    if (success) {
+      logger.info("Batch loaded {} rows", rows.size());
+    } else {
+      throw new ConnectException(String.format("Failed to load %d rows into GCS within %d re-attempts.", rows.size(), retries));
+    }
+
   }
 
   private static Map<String, String> getMetadata(TableId tableId) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -583,7 +583,7 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test (expected = ConversionConnectException.class)
-  public void testInValidMapSchemaless() {
+  public void testInvalidMapSchemaless() {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -560,6 +560,98 @@ public class BigQueryRecordConverterTest {
     assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
   }
 
+  @Test
+  public void testValidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(kafkaConnectMap, convertedMap);
+  }
+
+  @Test (expected = ConversionConnectException.class)
+  public void testInValidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put(1, "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+  }
+
+  @Test
+  public void testMapSchemalessConvertDouble() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", Double.POSITIVE_INFINITY);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", Double.POSITIVE_INFINITY);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Double.MAX_VALUE);
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Double.MAX_VALUE);
+    assertEquals(((ArrayList)((Map)(convertedMap.get("f3"))).get("f6")).get(1), Double.MAX_VALUE);
+  }
+
+  @Test
+  public void testMapSchemalessConvertBytes() {
+    byte[] helloWorld = "helloWorld".getBytes();
+    ByteBuffer helloWorldBuffer = ByteBuffer.wrap(helloWorld);
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", helloWorldBuffer);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", helloWorld);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Base64.getEncoder().encodeToString(helloWorld));
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Base64.getEncoder().encodeToString(helloWorld));
+  }
+
   private static SinkRecord spoofSinkRecord(Schema valueSchema, Object value) {
     return new SinkRecord(null, 0, null, null, valueSchema, value, 0);
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -1,0 +1,193 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2019 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.wepay.kafka.connect.bigquery.BigQuerySinkTask;
+import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GCSToBQWriterTest {
+
+  private static SinkTaskPropertiesFactory propertiesFactory;
+
+  @BeforeClass
+  public static void initializePropertiesFactory() {
+    propertiesFactory = new SinkTaskPropertiesFactory();
+  }
+
+  @Test
+  public void testGCSNoFailure(){
+    // test succeeding on first attempt
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    expectTable(bigQuery);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    verify(storage, times(1)).create((BlobInfo)anyObject(), (byte[])anyObject());
+  }
+
+  @Test
+  public void testGCSSomeFailures(){
+    // test failure through all configured retry attempts.
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    expectTable(bigQuery);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    when(storage.create((BlobInfo)anyObject(), (byte[])anyObject()))
+        .thenThrow(new StorageException(500, "internal server error")) // throw first time
+        .thenReturn(null); // return second time. (we don't care about the result.)
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    verify(storage, times(2)).create((BlobInfo)anyObject(), (byte[])anyObject());
+  }
+
+  @Test
+  public void testGCSAllFailures(){
+    // test failure through all configured retry attempts.
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    expectTable(bigQuery);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    when(storage.create((BlobInfo)anyObject(), (byte[])anyObject()))
+        .thenThrow(new StorageException(500, "internal server error"));
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    try {
+      testTask.flush(Collections.emptyMap());
+      Assert.fail("expected testTask.flush to fail.");
+    } catch (ConnectException ex){
+      verify(storage, times(4)).create((BlobInfo)anyObject(), (byte[])anyObject());
+    }
+  }
+
+  private void expectTable(BigQuery mockBigQuery) {
+    Table mockTable = mock(Table.class);
+    when(mockBigQuery.getTable(anyObject())).thenReturn(mockTable);
+  }
+
+  /**
+   * Utility method for making and retrieving properties based on provided parameters.
+   * @param bigqueryRetry The number of retries.
+   * @param bigqueryRetryWait The wait time for each retry.
+   * @param topic The topic of the record.
+   * @param dataset The dataset of the record.
+   * @return The map of bigquery sink configurations.
+   */
+  private Map<String,String> makeProperties(String bigqueryRetry,
+                                            String bigqueryRetryWait,
+                                            String topic,
+                                            String dataset) {
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+    // gcs config
+    properties.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG, "myBucket");
+    return properties;
+  }
+
+  /**
+   * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+   * @param topic The topic of the record.
+   * @param partition The partition of the record.
+   * @param field The name of the field in the record's struct.
+   * @param value The content of the field.
+   * @return The spoofed SinkRecord.
+   */
+  private SinkRecord spoofSinkRecord(String topic,
+                                     int partition,
+                                     long kafkaOffset,
+                                     String field,
+                                     String value) {
+    Schema basicRowSchema = SchemaBuilder
+        .struct()
+        .field(field, Schema.STRING_SCHEMA)
+        .build();
+    Struct basicRowValue = new Struct(basicRowSchema);
+    basicRowValue.put(field, value);
+    return new SinkRecord(topic,
+        partition,
+        null,
+        null,
+        basicRowSchema,
+        basicRowValue,
+        kafkaOffset,
+        null,
+        null);
+  }
+
+}

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -37,10 +37,11 @@ usage() {
        "[-p|--project <BigQuery project>]\n" \
        "[-d|--dataset <BigQuery project>]\n" \
        "[-b|--bucket <cloud Storage bucket>\n]" \
+       "[-f|--folder <cloud Storage folder under bucket>\n]" \
        1>&2
   echo 1>&2
   echo "Options can also be specified via environment variable:" \
-       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, and KCBQ_TEST_BUCKET" \
+       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, KCBQ_TEST_BUCKET, and KCBQ_TEST_FOLDER" \
        "respectively control the keyfile, project, dataset, and bucket." \
        1>&2
   echo 1>&2
@@ -100,6 +101,7 @@ KCBQ_TEST_KEYFILE=${KCBQ_TEST_KEYFILE:-$keyfile}
 KCBQ_TEST_PROJECT=${KCBQ_TEST_PROJECT:-$project}
 KCBQ_TEST_DATASET=${KCBQ_TEST_DATASET:-$dataset}
 KCBQ_TEST_BUCKET=${KCBQ_TEST_BUCKET:-$bucket}
+KCBQ_TEST_FOLDER=${KCBQ_TEST_FOLDER:-$folder}
 
 # Capture any command line flags
 while [[ $# -gt 0 ]]; do
@@ -123,6 +125,11 @@ while [[ $# -gt 0 ]]; do
         [[ -z "$2" ]] && { error "bucket name must follow $1 flag"; usage 1; }
         shift
         KCBQ_TEST_BUCKET="$1"
+        ;;
+    -b|--folder)
+        [[ -z "$2" ]] && { error "folder name must follow $1 flag"; usage 1; }
+        shift
+        KCBQ_TEST_FOLDER="$1"
         ;;
     -h|--help|'-?')
         usage 0
@@ -243,6 +250,8 @@ echo "datasets=.*=$KCBQ_TEST_DATASET" >> "$CONNECTOR_PROPS"
 
 echo "gcsBucketName=$KCBQ_TEST_BUCKET" >> "$CONNECTOR_PROPS"
 
+echo "gcsFolderName=$KCBQ_TEST_FOLDER" >> "$CONNECTOR_PROPS"
+
 echo -n 'topics=' >> "$CONNECTOR_PROPS"
 basename "$BASE_DIR"/resources/test_schemas/* \
   | sed -E 's/^(.*)$/kcbq_test_\1/' \
@@ -280,5 +289,6 @@ echo "keyfile=$KCBQ_TEST_KEYFILE" > "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "project=$KCBQ_TEST_PROJECT" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "dataset=$KCBQ_TEST_DATASET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "bucket=$KCBQ_TEST_BUCKET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
+echo "folder=$KCBQ_TEST_FOLDER" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 
 "$GRADLEW" -p "$BASE_DIR/.." cleanIntegrationTest integrationTest


### PR DESCRIPTION
What
----
Currently the BigQueryRecordConverter throws an error when schemaless JSON data is consumed. JsonConverter converts JSON to map before it arrives at the BigQuery connector. Therefore, instead of throwing null pointer error, the BigQueryRecordConverter should deal with schemaless data type.