### PR TITLE
Add methods for extracting google credential (follow example of gcs connector)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ project.ext {
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
+    jacksonVersion = '2.0.1'
     junitVersion = '4.12'
     kafkaVersion = '1.1.1'
     mockitoVersion = '1.10.19'
@@ -198,6 +199,7 @@ project(':kcbq-connector') {
                 "com.google.cloud:google-cloud:$googleCloudVersion",
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudVersion",
+                "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
@@ -17,18 +17,11 @@ package com.wepay.kafka.connect.bigquery;
  * under the License.
  */
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
-
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
-
+import com.wepay.kafka.connect.bigquery.utils.GoogleCredentialUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Convenience class for creating a default {@link com.google.cloud.bigquery.BigQuery} instance,
@@ -52,19 +45,14 @@ public class BigQueryHelper {
       return connect(projectName);
     }
 
-    logger.debug("Attempting to open file {} for service account json key", keyFilename);
-    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
-      logger.debug("Attempting to authenticate with BigQuery using provided json key");
-      return new
-          BigQueryOptions.DefaultBigQueryFactory().create(
-          BigQueryOptions.newBuilder()
-          .setProjectId(projectName)
-          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
-          .build()
-      );
-    } catch (IOException err) {
-      throw new BigQueryConnectException("Failed to access json key file", err);
-    }
+    logger.debug("Attempting to authenticate with BigQuery using provided json key");
+    return new
+        BigQueryOptions.DefaultBigQueryFactory().create(
+        BigQueryOptions.newBuilder()
+        .setProjectId(projectName)
+        .setCredentials(GoogleCredentialUtil.getCredentials(keyFilename))
+        .build()
+    );
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
@@ -19,9 +19,12 @@ package com.wepay.kafka.connect.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.GoogleCredentialUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Convenience class for creating a default {@link com.google.cloud.bigquery.BigQuery} instance,
@@ -46,13 +49,17 @@ public class BigQueryHelper {
     }
 
     logger.debug("Attempting to authenticate with BigQuery using provided json key");
-    return new
-        BigQueryOptions.DefaultBigQueryFactory().create(
-        BigQueryOptions.newBuilder()
-        .setProjectId(projectName)
-        .setCredentials(GoogleCredentialUtil.getCredentials(keyFilename))
-        .build()
-    );
+    try {
+      return new
+              BigQueryOptions.DefaultBigQueryFactory().create(
+              BigQueryOptions.newBuilder()
+                      .setProjectId(projectName)
+                      .setCredentials(GoogleCredentialUtil.getCredentials(keyFilename))
+                      .build()
+      );
+    } catch (IOException err){
+      throw new BigQueryConnectException("Failed to access json key file", err);
+    }
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
@@ -17,17 +17,11 @@ package com.wepay.kafka.connect.bigquery;
  * under the License.
  */
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-
-import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
+import com.wepay.kafka.connect.bigquery.utils.GoogleCredentialUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Convenience class for creating a {@link com.google.cloud.storage.Storage} instance
@@ -66,17 +60,12 @@ public class GCSBuilder {
       return connect(projectName);
     }
 
-    logger.debug("Attempting to open file {} for service account json key", keyFilename);
-    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
-      logger.debug("Attempting to authenticate with GCS using provided json key");
-      return StorageOptions.newBuilder()
-          .setProjectId(projectName)
-          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
-          .build()
-          .getService();
-    } catch (IOException err) {
-      throw new GCSConnectException("Failed to access json key file", err);
-    }
+    logger.debug("Attempting to authenticate with GCS using provided json key");
+    return StorageOptions.newBuilder()
+        .setProjectId(projectName)
+        .setCredentials(GoogleCredentialUtil.getCredentials(keyFileName))
+        .build()
+        .getService();
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
@@ -19,9 +19,12 @@ package com.wepay.kafka.connect.bigquery;
 
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
 import com.wepay.kafka.connect.bigquery.utils.GoogleCredentialUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Convenience class for creating a {@link com.google.cloud.storage.Storage} instance
@@ -61,11 +64,15 @@ public class GCSBuilder {
     }
 
     logger.debug("Attempting to authenticate with GCS using provided json key");
-    return StorageOptions.newBuilder()
-        .setProjectId(projectName)
-        .setCredentials(GoogleCredentialUtil.getCredentials(keyFileName))
-        .build()
-        .getService();
+    try {
+      return StorageOptions.newBuilder()
+              .setProjectId(projectName)
+              .setCredentials(GoogleCredentialUtil.getCredentials(keyFileName))
+              .build()
+              .getService();
+    } catch (IOException err) {
+      throw new GCSConnectException("Failed to access json key file", err);
+    }
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GoogleCredentialUtil.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GoogleCredentialUtil.java
@@ -2,7 +2,6 @@ package com.wepay.kafka.connect.bigquery.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,17 +31,13 @@ public class GoogleCredentialUtil {
   private static final String CLIENT_EMAIL = "client_email";
   private static final String CLIENT_ID = "client_id";
 
-  public static GoogleCredentials getCredentials(String fileName) {
+  public static GoogleCredentials getCredentials(String fileName) throws IOException{
     logger.debug("Attempting to open file {} for service account json key", fileName);
-    try {
-      if (isValidJsonFile(fileName)) {
-        return GoogleCredentials
-                .fromStream(new FileInputStream(fileName));
-      } else {
-        return buildCredentialsFromProperties(fileName);
-      }
-    } catch (IOException e) {
-      throw new BigQueryConnectException("No valid credentials source was provided.");
+    if (isValidJsonFile(fileName)) {
+      return GoogleCredentials
+              .fromStream(new FileInputStream(fileName));
+    } else {
+      return buildCredentialsFromProperties(fileName);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GoogleCredentialUtil.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GoogleCredentialUtil.java
@@ -1,0 +1,106 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class GoogleCredentialUtil {
+  private static final Logger logger = LoggerFactory.getLogger(GoogleCredentialUtil.class);
+
+  private static final String GOOGLE_API_URL = "https://www.googleapis.com/auth/cloud-platform";
+  private static final String GOOGLE_ACCOUNT_TYPE = "type";
+  private static final String PROJECT_ID = "project_id";
+  private static final String PRIVATE_KEY_ID = "private_key_id";
+  private static final String PRIVATE_KEY = "private_key";
+  private static final String CLIENT_EMAIL = "client_email";
+  private static final String CLIENT_ID = "client_id";
+
+  public static GoogleCredentials getCredentials(String fileName) {
+    logger.debug("Attempting to open file {} for service account json key", fileName);
+    try {
+      if (isValidJsonFile(fileName)) {
+        return GoogleCredentials
+                .fromStream(new FileInputStream(fileName));
+      } else {
+        return buildCredentialsFromProperties(fileName);
+      }
+    } catch (IOException e) {
+      throw new BigQueryConnectException("No valid credentials source was provided.");
+    }
+  }
+
+  private static String readAllBytesFromFile(String filePath) throws IOException {
+    String content = "";
+    try {
+      content = new String(Files.readAllBytes(
+              Paths.get(filePath)), StandardCharsets.UTF_8.name());
+    } catch (IOException e) {
+      throw new IOException(
+              "Unable to read contents of credentials file at: " + filePath, e);
+    }
+    return content;
+  }
+
+  private static boolean isValidJsonFile(String pathToFile) {
+    try {
+      final ObjectMapper mapper = new ObjectMapper();
+      mapper.readTree(readAllBytesFromFile(pathToFile));
+      return true;
+    } catch (IOException e) {
+      logger.warn("Input file is not valid json", e);
+    }
+    return false;
+  }
+
+  private static GoogleCredentials buildCredentialsFromProperties(
+          String pathToCredentials
+  ) throws IOException {
+    try (FileInputStream credentialsStream = new FileInputStream(pathToCredentials)) {
+      Properties prop = new Properties();
+      prop.load(credentialsStream);
+      Set<String> credentialsFields = new HashSet<>();
+      credentialsFields.add(GOOGLE_ACCOUNT_TYPE);
+      credentialsFields.add(PROJECT_ID);
+      credentialsFields.add(PRIVATE_KEY_ID);
+      credentialsFields.add(PRIVATE_KEY);
+      credentialsFields.add(CLIENT_EMAIL);
+      credentialsFields.add(CLIENT_ID);
+      Map<String, String> valueMap = new HashMap<>();
+      prop.forEach((k,v) -> valueMap.put((String)k, (String)v));
+      Map<String, String> credentialsMap = new HashMap<>();
+      for (Map.Entry<String,String> entry : valueMap.entrySet()) {
+        String key = entry.getKey().replaceAll("\"", "").replaceAll(",", "");
+        if (credentialsFields.contains(key)) {
+          String val = entry.getValue().replaceAll("\"", "").replaceAll(",", "");
+          credentialsMap.put(key, val);
+        }
+      }
+      String jsonString = new ObjectMapper().writeValueAsString(credentialsMap);
+      InputStream is = new ByteArrayInputStream(
+              jsonString.getBytes(Charset.forName(StandardCharsets.UTF_8.name())));
+      return GoogleCredentials.fromStream(is)
+              .createScoped(Collections.singletonList(GOOGLE_API_URL));
+    } catch (IOException e) {
+      logger.error("Unable to build credentials from properties file", e);
+      throw e;
+    }
+  }
+
+}


### PR DESCRIPTION
Add method to read google credential from secret properties file, so that the connector can use the credential service in cloud.
Follow example of GCS:
https://github.com/confluentinc/kafka-connect-storage-cloud-private/pull/49/files#diff-be8080566b8c71281840f840a1b67283