### PR TITLE
FMC-463: Fail task if error is encountered when writing to BigQuery

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -231,7 +231,7 @@ public class BigQuerySinkTask extends SinkTask {
 
     // add tableWriters to the executor work queue
     for (TableWriterBuilder builder : tableWriterBuilders.values()) {
-      executor.submit(builder.build());
+      executor.execute(builder.build());
     }
     executor.checkError();
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -232,8 +232,8 @@ public class BigQuerySinkTask extends SinkTask {
     // add tableWriters to the executor work queue
     for (TableWriterBuilder builder : tableWriterBuilders.values()) {
       executor.submit(builder.build());
-      executor.checkError();
     }
+    executor.checkError();
 
     // check if we should pause topics
     long queueSoftLimit = config.getLong(BigQuerySinkTaskConfig.QUEUE_SIZE_CONFIG);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -184,12 +184,12 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
-    logger.info("Putting {} records in the sink.", records.size());
     // check for non-retriable errors and fail the task if any.
     // adding this because any Exception thrown in flush will be ignored by the framework, which
     // causes the connector to retry inserting the same batch of records.
     executor.checkForErrors();
 
+    logger.info("Putting {} records in the sink.", records.size());
     // create tableWriters
     Map<PartitionedTableId, TableWriterBuilder> tableWriterBuilders = new HashMap<>();
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -187,7 +187,7 @@ public class BigQuerySinkTask extends SinkTask {
     // check for non-retriable errors and fail the task if any.
     // adding this because any Exception thrown in flush will be ignored by the framework, which
     // causes the connector to retry inserting the same batch of records.
-    executor.checkForErrors();
+    executor.maybeFail();
 
     logger.info("Putting {} records in the sink.", records.size());
     // create tableWriters

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -229,21 +229,10 @@ public class BigQuerySinkTask extends SinkTask {
       }
     }
 
-    List<Future<?>> futures = new ArrayList<>();
     // add tableWriters to the executor work queue
     for (TableWriterBuilder builder : tableWriterBuilders.values()) {
-      futures.add(executor.submit(builder.build()));
-    }
-    // Check for non-retriable errors and fail the task if any.
-    // Adding this check because any Exception thrown in flush will be ignored by the framework,
-    // which causes the connector to keep reading the same batch of records without showing any
-    // error to the user.
-    for (Future<?> future : futures) {
-      try {
-        future.get();
-      } catch (InterruptedException | ExecutionException e) {
-        throw new BigQueryConnectException(e);
-      }
+      executor.submit(builder.build());
+      executor.checkError();
     }
 
     // check if we should pause topics

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -234,6 +234,10 @@ public class BigQuerySinkTask extends SinkTask {
     for (TableWriterBuilder builder : tableWriterBuilders.values()) {
       futures.add(executor.submit(builder.build()));
     }
+    // Check for non-retriable errors and fail the task if any.
+    // Adding this check because any Exception thrown in flush will be ignored by the framework,
+    // which causes the connector to keep reading the same batch of records without showing any
+    // error to the user.
     for (Future<?> future : futures) {
       try {
         future.get();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -93,7 +93,6 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
     countDownLatch.await();
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
-      encounteredErrors.clear();
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
                                          + errorString + "; See logs for more detail");
     }
@@ -113,11 +112,9 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
    * @throws BigQueryConnectException if there have been any unrecoverable errors when writing to BigQuery.
    */
   public void checkForErrors() throws BigQueryConnectException {
-    synchronized (encounteredErrors) {
-      if (encounteredErrors.size() > 0) {
-        throw new BigQueryConnectException("Encountered unrecoverable errors: "
-            + createErrorString(encounteredErrors) + "; See logs for more detail");
-      }
+    if (encounteredErrors.size() > 0) {
+      throw new BigQueryConnectException("Encountered unrecoverable errors: "
+          + createErrorString(encounteredErrors) + "; See logs for more detail");
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -44,7 +44,7 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   private static final Logger logger = LoggerFactory.getLogger(KCBQThreadPoolExecutor.class);
 
 
-  private ConcurrentHashMap.KeySetView<Throwable, Boolean> encounteredErrors =
+  private final ConcurrentHashMap.KeySetView<Throwable, Boolean> encounteredErrors =
       ConcurrentHashMap.newKeySet();
 
   /**
@@ -108,8 +108,10 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   }
 
   public void checkError() throws BigQueryConnectException {
-    if (encounteredErrors.size() > 0) {
-      throw new BigQueryConnectException("Encountered errors while writing to BigQuery");
+    synchronized (encounteredErrors) {
+      if (encounteredErrors.size() > 0) {
+        throw new BigQueryConnectException("Encountered errors while writing to BigQuery");
+      }
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -70,7 +70,6 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
                    throwable.getMessage());
       logger.debug("Error Task Stacktrace:", throwable);
       encounteredErrors.add(throwable);
-      throw new BigQueryConnectException(throwable);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -107,11 +107,15 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
     return String.join(", ", exceptionTypeStrings);
   }
 
-  public void checkError() throws BigQueryConnectException {
-    synchronized (encounteredErrors) {
-      if (encounteredErrors.size() > 0) {
-        throw new BigQueryConnectException("Encountered errors while writing to BigQuery");
-      }
+  /**
+   * Checks for BigQuery errors. No-op if there isn't any error.
+   *
+   * @throws BigQueryConnectException if there is any error when writing to BigQuery.
+   */
+  public void checkForErrors() throws BigQueryConnectException {
+    if (encounteredErrors.size() > 0) {
+      throw new BigQueryConnectException("Encountered unrecoverable errors while writing to "
+          + "BigQuery. See logs for more detail");
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -113,9 +113,11 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
    * @throws BigQueryConnectException if there is any error when writing to BigQuery.
    */
   public void checkForErrors() throws BigQueryConnectException {
-    if (encounteredErrors.size() > 0) {
-      throw new BigQueryConnectException("Encountered unrecoverable errors while writing to "
-          + "BigQuery. See logs for more detail");
+    synchronized (encounteredErrors) {
+      if (encounteredErrors.size() > 0) {
+        throw new BigQueryConnectException("Encountered unrecoverable errors: "
+            + createErrorString(encounteredErrors) + "; See logs for more detail");
+      }
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -70,6 +70,7 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
                    throwable.getMessage());
       logger.debug("Error Task Stacktrace:", throwable);
       encounteredErrors.add(throwable);
+      throw new BigQueryConnectException(throwable);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -43,7 +43,6 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
 
   private static final Logger logger = LoggerFactory.getLogger(KCBQThreadPoolExecutor.class);
 
-
   private final ConcurrentHashMap.KeySetView<Throwable, Boolean> encounteredErrors =
       ConcurrentHashMap.newKeySet();
 
@@ -106,15 +105,24 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
     return String.join(", ", exceptionTypeStrings);
   }
 
+  private static String createDetailedErrorString(Collection<Throwable> errors) {
+    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
+    exceptionTypeStrings.addAll(errors.stream()
+        .map(throwable ->
+            throwable.getClass().getName() + "\nMessage: " + throwable.getLocalizedMessage())
+        .collect(Collectors.toList()));
+    return String.join(", ", exceptionTypeStrings);
+  }
+
   /**
    * Checks for BigQuery errors. No-op if there isn't any error.
    *
    * @throws BigQueryConnectException if there have been any unrecoverable errors when writing to BigQuery.
    */
-  public void checkForErrors() throws BigQueryConnectException {
+  public void maybeFail() throws BigQueryConnectException {
     if (encounteredErrors.size() > 0) {
       throw new BigQueryConnectException("Encountered unrecoverable errors: "
-          + createErrorString(encounteredErrors) + "; See logs for more detail");
+          + createDetailedErrorString(encounteredErrors) + "; See logs for more detail");
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -110,7 +110,7 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   /**
    * Checks for BigQuery errors. No-op if there isn't any error.
    *
-   * @throws BigQueryConnectException if there is any error when writing to BigQuery.
+   * @throws BigQueryConnectException if there have been any unrecoverable errors when writing to BigQuery.
    */
   public void checkForErrors() throws BigQueryConnectException {
     synchronized (encounteredErrors) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -106,4 +106,10 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
                         .collect(Collectors.toList()));
     return String.join(", ", exceptionTypeStrings);
   }
+
+  public void checkError() throws BigQueryConnectException {
+    if (encounteredErrors.size() > 0) {
+      throw new BigQueryConnectException("Encountered errors while writing to BigQuery");
+    }
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -85,6 +85,8 @@ public class TableWriter implements Runnable {
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize);
+          } else {
+            throw err;
           }
         }
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -85,8 +85,6 @@ public class TableWriter implements Runnable {
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize);
-          } else {
-            throw err;
           }
         }
       }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -310,11 +310,10 @@ public class BigQuerySinkTaskTest {
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
-
-    when(bigQuery.insertAll(any())).thenThrow(new BigQueryException(
-        400, "no such field",
-        new BigQueryError("no such field", "us-central1", "")));
+    when(bigQuery.insertAll(any())).thenReturn(insertAllResponse);
     when(insertAllResponse.hasErrors()).thenReturn(true);
+    when(insertAllResponse.getInsertErrors()).thenReturn(Collections.singletonMap(
+       0L, Collections.singletonList(new BigQueryError("no such field", "us-central1", ""))));
 
     SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
     SchemaManager schemaManager = mock(SchemaManager.class);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -327,7 +327,6 @@ public class BigQuerySinkTaskTest {
     testTask.flush(Collections.emptyMap());
   }
 
-
   // It's important that the buffer be completely wiped after a call to flush, since any execption
   // thrown during flush causes Kafka Connect to not commit the offsets for any records sent to the
   // task since the last flush

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -298,7 +298,7 @@ public class BigQuerySinkTaskTest {
   }
 
   @Test(expected = BigQueryConnectException.class)
-  public void testSimplePutException() {
+  public void testSimplePutException() throws InterruptedException {
     final String topic = "test-topic";
 
     Map<String, String> properties = propertiesFactory.getProperties();
@@ -323,7 +323,8 @@ public class BigQuerySinkTaskTest {
     testTask.start(properties);
 
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
-    testTask.flush(Collections.emptyMap());
+    Thread.sleep(100);
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
   }
 
   // It's important that the buffer be completely wiped after a call to flush, since any execption

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -329,11 +329,11 @@ public class BigQuerySinkTaskTest {
     }
   }
 
-  // It's important that the buffer be completely wiped after a call to flush, since any execption
-  // thrown during flush causes Kafka Connect to not commit the offsets for any records sent to the
-  // task since the last flush
-  @Test
-  public void testBufferClearOnFlushError() {
+  // Since any exception thrown during flush causes Kafka Connect to not commit the offsets for any
+  // records sent to the task since the last flush. The task should fail, and next flush should
+  // also throw an error.
+  @Test(expected = BigQueryConnectException.class)
+  public void testFlushException() {
     final String dataset = "scratch";
     final String topic = "test_topic";
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -297,7 +297,7 @@ public class BigQuerySinkTaskTest {
         TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
-  @Test(expected = BigQueryConnectException.class)
+  @Test(expected = BigQueryConnectException.class, timeout = 60000L)
   public void testSimplePutException() throws InterruptedException {
     final String topic = "test-topic";
 
@@ -323,8 +323,10 @@ public class BigQuerySinkTaskTest {
     testTask.start(properties);
 
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
-    Thread.sleep(100);
-    testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
+    while (true) {
+      Thread.sleep(100);
+      testTask.put(Collections.emptyList());
+    }
   }
 
   // It's important that the buffer be completely wiped after a call to flush, since any execption

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -324,6 +324,7 @@ public class BigQuerySinkTaskTest {
     testTask.start(properties);
 
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
+    testTask.flush(Collections.emptyMap());
   }
 
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -200,16 +200,16 @@ public class BigQueryRecordConverterTest {
       bigQueryExpectedRecord.put(fieldName, expectedValues.get(test));
 
       Schema kafkaConnectSchema = SchemaBuilder
-              .struct()
-              .field(fieldName, Schema.FLOAT64_SCHEMA)
-              .build();
+          .struct()
+          .field(fieldName, Schema.FLOAT64_SCHEMA)
+          .build();
 
       Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);
       kafkaConnectStruct.put(fieldName, testValues.get(test));
       SinkRecord kafkaConnectRecord = spoofSinkRecord(kafkaConnectSchema, kafkaConnectStruct, false);
 
       Map<String, Object> bigQueryTestRecord =
-              new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+          new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
       assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
     }
   }
@@ -598,8 +598,8 @@ public class BigQueryRecordConverterTest {
     Schema kafkaConnectSchema = SchemaBuilder
         .struct()
         .field(nullableFieldName,
-               SchemaBuilder.struct().field("foobar",
-                                            SchemaBuilder.bool().build()).optional().build())
+            SchemaBuilder.struct().field("foobar",
+                SchemaBuilder.bool().build()).optional().build())
         .build();
 
     Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);
@@ -617,20 +617,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,
-              new HashMap<Object, Object>(){{
-                put("f4", "false");
-                put("f5", true);
-                put("f6", new ArrayList<String>(){{
-                  add("hello");
-                  add("world");
-                }});
-              }}
+          new HashMap<Object, Object>(){{
+            put("f4", "false");
+            put("f5", true);
+            put("f6", new ArrayList<String>(){{
+              add("hello");
+              add("world");
+            }});
+          }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, true);
     Map<String, Object> convertedMap =
-            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
     assertEquals(kafkaConnectMap, convertedMap);
   }
 
@@ -639,20 +639,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,
-              new HashMap<Object, Object>(){{
-                put(1, "false");
-                put("f5", true);
-                put("f6", new ArrayList<String>(){{
-                  add("hello");
-                  add("world");
-                }});
-              }}
+          new HashMap<Object, Object>(){{
+            put(1, "false");
+            put("f5", true);
+            put("f6", new ArrayList<String>(){{
+              add("hello");
+              add("world");
+            }});
+          }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, false);
     Map<String, Object> convertedMap =
-            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
   }
 
   @Test
@@ -687,55 +687,24 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test
-  public void testInvalidMapSchemalessNullValue() {
-    Map kafkaConnectMap = new HashMap<Object, Object>(){{
-      put("f1", "abc");
-      put("f2", "abc");
-      put("f3", null);
-    }};
-
-    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
-    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
-    Assert.assertEquals(kafkaConnectMap, stringObjectMap
-    );
-  }
-
-  @Test
-  public void testInvalidMapSchemalessNestedMapNullValue() {
-    Map kafkaConnectMap = new HashMap<Object, Object>(){{
-      put("f1", "abc");
-      put("f2", "abc");
-      put("f3", new HashMap<Object, Object>() {{
-        put("f31", "xyz");
-        put("f32", null);
-      }});
-    }};
-
-    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
-    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE)
-        .convertRecord(kafkaConnectRecord);
-    Assert.assertEquals(kafkaConnectMap, stringObjectMap);
-  }
-
-  @Test
   public void testMapSchemalessConvertDouble() {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", Double.POSITIVE_INFINITY);
       put( "f3" ,
-              new HashMap<Object, Object>(){{
-                put("f4", Double.POSITIVE_INFINITY);
-                put("f5", true);
-                put("f6", new ArrayList<Double>(){{
-                  add(1.2);
-                  add(Double.POSITIVE_INFINITY);
-                }});
-              }}
+          new HashMap<Object, Object>(){{
+            put("f4", Double.POSITIVE_INFINITY);
+            put("f5", true);
+            put("f6", new ArrayList<Double>(){{
+              add(1.2);
+              add(Double.POSITIVE_INFINITY);
+            }});
+          }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, true);
     Map<String, Object> convertedMap =
-            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
     assertEquals(convertedMap.get("f1"), Double.MAX_VALUE);
     assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Double.MAX_VALUE);
     assertEquals(((ArrayList)((Map)(convertedMap.get("f3"))).get("f6")).get(1), Double.MAX_VALUE);
@@ -748,20 +717,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", helloWorldBuffer);
       put( "f3" ,
-              new HashMap<Object, Object>(){{
-                put("f4", helloWorld);
-                put("f5", true);
-                put("f6", new ArrayList<Double>(){{
-                  add(1.2);
-                  add(Double.POSITIVE_INFINITY);
-                }});
-              }}
+          new HashMap<Object, Object>(){{
+            put("f4", helloWorld);
+            put("f5", true);
+            put("f6", new ArrayList<Double>(){{
+              add(1.2);
+              add(Double.POSITIVE_INFINITY);
+            }});
+          }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, false);
     Map<String, Object> convertedMap =
-            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
     assertEquals(convertedMap.get("f1"), Base64.getEncoder().encodeToString(helloWorld));
     assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Base64.getEncoder().encodeToString(helloWorld));
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -200,16 +200,16 @@ public class BigQueryRecordConverterTest {
       bigQueryExpectedRecord.put(fieldName, expectedValues.get(test));
 
       Schema kafkaConnectSchema = SchemaBuilder
-          .struct()
-          .field(fieldName, Schema.FLOAT64_SCHEMA)
-          .build();
+              .struct()
+              .field(fieldName, Schema.FLOAT64_SCHEMA)
+              .build();
 
       Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);
       kafkaConnectStruct.put(fieldName, testValues.get(test));
       SinkRecord kafkaConnectRecord = spoofSinkRecord(kafkaConnectSchema, kafkaConnectStruct, false);
 
       Map<String, Object> bigQueryTestRecord =
-          new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+              new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
       assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
     }
   }
@@ -598,8 +598,8 @@ public class BigQueryRecordConverterTest {
     Schema kafkaConnectSchema = SchemaBuilder
         .struct()
         .field(nullableFieldName,
-            SchemaBuilder.struct().field("foobar",
-                SchemaBuilder.bool().build()).optional().build())
+               SchemaBuilder.struct().field("foobar",
+                                            SchemaBuilder.bool().build()).optional().build())
         .build();
 
     Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);
@@ -617,20 +617,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,
-          new HashMap<Object, Object>(){{
-            put("f4", "false");
-            put("f5", true);
-            put("f6", new ArrayList<String>(){{
-              add("hello");
-              add("world");
-            }});
-          }}
+              new HashMap<Object, Object>(){{
+                put("f4", "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, true);
     Map<String, Object> convertedMap =
-        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
     assertEquals(kafkaConnectMap, convertedMap);
   }
 
@@ -639,20 +639,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,
-          new HashMap<Object, Object>(){{
-            put(1, "false");
-            put("f5", true);
-            put("f6", new ArrayList<String>(){{
-              add("hello");
-              add("world");
-            }});
-          }}
+              new HashMap<Object, Object>(){{
+                put(1, "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, false);
     Map<String, Object> convertedMap =
-        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
   }
 
   @Test
@@ -687,24 +687,55 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test
+  public void testInvalidMapSchemalessNullValue() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "abc");
+      put("f2", "abc");
+      put("f3", null);
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    Assert.assertEquals(kafkaConnectMap, stringObjectMap
+    );
+  }
+
+  @Test
+  public void testInvalidMapSchemalessNestedMapNullValue() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "abc");
+      put("f2", "abc");
+      put("f3", new HashMap<Object, Object>() {{
+        put("f31", "xyz");
+        put("f32", null);
+      }});
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE)
+        .convertRecord(kafkaConnectRecord);
+    Assert.assertEquals(kafkaConnectMap, stringObjectMap);
+  }
+
+  @Test
   public void testMapSchemalessConvertDouble() {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", Double.POSITIVE_INFINITY);
       put( "f3" ,
-          new HashMap<Object, Object>(){{
-            put("f4", Double.POSITIVE_INFINITY);
-            put("f5", true);
-            put("f6", new ArrayList<Double>(){{
-              add(1.2);
-              add(Double.POSITIVE_INFINITY);
-            }});
-          }}
+              new HashMap<Object, Object>(){{
+                put("f4", Double.POSITIVE_INFINITY);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, true);
     Map<String, Object> convertedMap =
-        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.KEY);
     assertEquals(convertedMap.get("f1"), Double.MAX_VALUE);
     assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Double.MAX_VALUE);
     assertEquals(((ArrayList)((Map)(convertedMap.get("f3"))).get("f6")).get(1), Double.MAX_VALUE);
@@ -717,20 +748,20 @@ public class BigQueryRecordConverterTest {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", helloWorldBuffer);
       put( "f3" ,
-          new HashMap<Object, Object>(){{
-            put("f4", helloWorld);
-            put("f5", true);
-            put("f6", new ArrayList<Double>(){{
-              add(1.2);
-              add(Double.POSITIVE_INFINITY);
-            }});
-          }}
+              new HashMap<Object, Object>(){{
+                put("f4", helloWorld);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
       );
     }};
 
     SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap, false);
     Map<String, Object> convertedMap =
-        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord, KafkaSchemaRecordType.VALUE);
     assertEquals(convertedMap.get("f1"), Base64.getEncoder().encodeToString(helloWorld));
     assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Base64.getEncoder().encodeToString(helloWorld));
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -687,37 +687,6 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test
-  public void testInvalidMapSchemalessNullValue() {
-    Map kafkaConnectMap = new HashMap<Object, Object>(){{
-      put("f1", "abc");
-      put("f2", "abc");
-      put("f3", null);
-    }};
-
-    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
-    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
-    Assert.assertEquals(kafkaConnectMap, stringObjectMap
-    );
-  }
-
-  @Test
-  public void testInvalidMapSchemalessNestedMapNullValue() {
-    Map kafkaConnectMap = new HashMap<Object, Object>(){{
-      put("f1", "abc");
-      put("f2", "abc");
-      put("f3", new HashMap<Object, Object>() {{
-        put("f31", "xyz");
-        put("f32", null);
-      }});
-    }};
-
-    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
-    Map<String, Object> stringObjectMap = new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE)
-        .convertRecord(kafkaConnectRecord);
-    Assert.assertEquals(kafkaConnectMap, stringObjectMap);
-  }
-
-  @Test
   public void testMapSchemalessConvertDouble() {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", Double.POSITIVE_INFINITY);


### PR DESCRIPTION
Background: 
The connector writes to BigQuery using a separate thread pool, which means that errors encountered during those writes don’t immediately cause the task to fail. Those errors aren’t swallowed silently, however, and do cause the task to throw an exception from its [`flush method`](https://github.com/wepay/kafka-connect-bigquery/blob/4fb38a8f4b3b6db065976639c57106db9896f0db/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java#L127) when invoking [`KCBQThreadPoolExecutor::awaitCurrentTasks`](https://github.com/wepay/kafka-connect-bigquery/blob/4fb38a8f4b3b6db065976639c57106db9896f0db/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java#L76-L100).

Unfortunately, the framework does not fail tasks when they throw exceptions from their [`flush method`](https://github.com/apache/kafka/blob/73ec7304b9e13cf4b9da05f215bd356a84efe0e7/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L384-L397) (which is indirectly called as a result of invoking SinkTask::preCommit), and instead, [logs the error and resets the consumer to the last successful offset](https://github.com/apache/kafka/blob/73ec7304b9e13cf4b9da05f215bd356a84efe0e7/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java#L384-L397).

We should do some digging into what the actual contract provided by the framework with regards to `SinkTask::flush` and `SinkTask::preCommit` is, specifically for when a call to them fails. It’s possible that this is a bug in the framework, but if the behavior we’re seeing is well-documented and intended, then the connector should be adjusted to throw the exception from somewhere else in order to actually fail the task.

This commit exposes the Exception in `BigQuerySinkTask::put`, so the task can fail without keeping reading the same batch of problematic records.