### PR TITLE
CC-9208: Include original trace in worker trace when task fails.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -287,10 +287,8 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
-    if (upsertDelete) {
-      // Periodically poll for errors here instead of doing a stop-the-world check in flush()
-      executor.maybeThrowEncounteredErrors();
-    }
+    // Periodically poll for errors here instead of doing a stop-the-world check in flush()
+    executor.maybeThrowEncounteredErrors();
 
     logger.debug("Putting {} records in the sink.", records.size());
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -61,4 +61,9 @@ public class BigQueryConnectException extends ConnectException {
     }
     return messageBuilder.toString();
   }
+
+  public String toString() {
+    return getCause() != null ?
+        super.toString() + "\nCaused by: " + getCause().getLocalizedMessage() : super.toString();
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -62,6 +62,7 @@ public class BigQueryConnectException extends ConnectException {
     return messageBuilder.toString();
   }
 
+  @Override
   public String toString() {
     return getCause() != null ?
         super.toString() + "\nCaused by: " + getCause().getLocalizedMessage() : super.toString();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -61,9 +61,4 @@ public class BigQueryConnectException extends ConnectException {
     }
     return messageBuilder.toString();
   }
-
-  public String toString() {
-    return getCause() != null ?
-        super.toString() + "\nCaused by: " + getCause().getLocalizedMessage() : super.toString();
-  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -117,19 +117,4 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
                  .map(Objects::toString)
                  .collect(Collectors.joining(", "));
   }
-
-  private static String createDetailedErrorString(Collection<Throwable> errors) {
-    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
-    exceptionTypeStrings.addAll(errors.stream()
-        .map(throwable -> {
-          String errorMessage =
-              throwable.getClass().getName() + "\nMessage: " + throwable.getLocalizedMessage();
-          if (throwable.getCause() != null) {
-            errorMessage += "\nCaused by: " + throwable.getCause().getLocalizedMessage();
-          }
-          return errorMessage;
-        })
-        .collect(Collectors.toList()));
-    return String.join(", ", exceptionTypeStrings);
-  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -21,8 +21,6 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
-import java.util.ArrayList;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -104,7 +104,6 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   public void maybeThrowEncounteredErrors() {
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
-      encounteredErrors.clear();
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
           + errorString + "; See logs for more detail");
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -21,6 +21,8 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,6 @@ import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -115,5 +116,20 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
     return errors.stream()
                  .map(Objects::toString)
                  .collect(Collectors.joining(", "));
+  }
+
+  private static String createDetailedErrorString(Collection<Throwable> errors) {
+    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
+    exceptionTypeStrings.addAll(errors.stream()
+        .map(throwable -> {
+          String errorMessage =
+              throwable.getClass().getName() + "\nMessage: " + throwable.getLocalizedMessage();
+          if (throwable.getCause() != null) {
+            errorMessage += "\nCaused by: " + throwable.getCause().getLocalizedMessage();
+          }
+          return errorMessage;
+        })
+        .collect(Collectors.toList()));
+    return String.join(", ", exceptionTypeStrings);
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -120,7 +120,7 @@ public class TableWriter implements Runnable {
   private static int getNewBatchSize(int currentBatchSize, Throwable err) {
     if (currentBatchSize == 1) {
       // todo correct exception type?
-      throw new ConnectException("Attempted to reduce batch size below 1.", err);
+      throw new BigQueryConnectException("Attempted to reduce batch size below 1.", err);
     }
     // round batch size up so we don't end up with a dangling 1 row at the end.
     return (int) Math.ceil(currentBatchSize / 2.0);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -97,6 +97,9 @@ public class TableWriter implements Runnable {
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);
+          } else {
+            // Throw exception on write errors such as 403.
+            throw new BigQueryConnectException("Failed to write to table", err);
           }
         }
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -97,8 +97,6 @@ public class TableWriter implements Runnable {
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);
-          } else {
-            throw new BigQueryConnectException("Failed to write to table", err);
           }
         }
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -119,7 +119,7 @@ public class TableWriter implements Runnable {
     onFinish.accept(rows);
   }
 
-  private static int getNewBatchSize(int currentBatchSize, BigQueryException err) {
+  private static int getNewBatchSize(int currentBatchSize, Throwable err) {
     if (currentBatchSize == 1) {
       // todo correct exception type?
       throw new ConnectException("Attempted to reduce batch size below 1.", err);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -21,7 +21,6 @@ package com.wepay.kafka.connect.bigquery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
@@ -67,7 +66,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
@@ -413,8 +411,8 @@ public class BigQuerySinkTaskTest {
     SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
     SchemaManager schemaManager = mock(SchemaManager.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage,
-        schemaManager);
+    BigQuerySinkTask testTask =
+        new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -454,9 +454,14 @@ public class BigQuerySinkTaskTest {
     testTask.start(properties);
 
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
-    while (true) {
-      Thread.sleep(100);
-      testTask.put(Collections.emptyList());
+    try {
+      while (true) {
+        Thread.sleep(100);
+        testTask.put(Collections.emptyList());
+      }
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains(error));
+      throw e;
     }
   }
 


### PR DESCRIPTION
## Problem
In some cases, BigQuery connector exception in async thread are not surfaces. As a result, the worker trace only shows generic error message like `com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Encountered unrecoverable errors: org.apache.kafka.connect.errors.ConnectException\nMessage: Attempted to reduce batch size below 1.; See logs for more detail`. User has to go check the logs and see what happened. While this isn't a big issue for on-prem, it makes the cloud experience bad as user doesn't know what action they should take to fix the problem. And it adds to oncall burden.

## Solution
Propagate error trace back to top level, so we can add error mapping to instruct users what they can do to make the connector work.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

Currently, schema mismatch error is already in top level trace.
This change can expose the following cases:
- [x] The destination table has no schema
- [x] Partition by column (Originally a `ConnectException` without detail)
- [x] Cannot add required fields to an existing schema (Originally a `ConnectException` without detail)
- [x] User does not have bigquery.tables.updateData permission (Original task doesn't fail)

Sample trace:
No schema
```
"trace": "org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:580)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:223)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:195)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
at java.base/java.lang.Thread.run(Thread.java:832)\nCaused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Some write threads encountered unrecoverable errors: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Attempted to reduce batch size below 1.
Caused by: The destination table has no schema., com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Attempted to reduce batch size below 1.
Caused by: The destination table has no schema., com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Attempted to reduce batch size below 1.
Caused by: The destination table has no schema.; See logs for more detail
at com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor.maybeThrowEncounteredErrors(KCBQThreadPoolExecutor.java:107)
at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.put(BigQuerySinkTask.java:291)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:558)
... 10 more"
```
Partitioning by column
```
"trace": "org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:580)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:223)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:195)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Some write threads encountered unrecoverable errors: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Attempted to reduce batch size below 1.
Caused by: Streaming to metadata partition of column based partitioning table cloud-private-dev:test_bq.partition_by_timestamp_column$20200713 is disallowed.; See logs for more detail
at com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor.maybeThrowEncounteredErrors(KCBQThreadPoolExecutor.java:107)
at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.put(BigQuerySinkTask.java:291)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:558)
... 10 more"
```
Failed to update schema
```
"trace": "org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:580)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:223)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:195)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Some write threads encountered unrecoverable errors: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Failed to update table schema for: GenericData{classInfo=[datasetId, projectId, tableId], {datasetId=test_bq, tableId=mismatch_schema}}
Caused by: Provided Schema does not match Table cloud-private-dev:test_bq.mismatch_schema. Cannot add required fields to an existing schema. (field: level); See logs for more detail
at com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor.maybeThrowEncounteredErrors(KCBQThreadPoolExecutor.java:110)
at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.put(BigQuerySinkTask.java:291)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:558)
... 10 more"
```
Insufficient permission
```
"trace": "org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:580)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:223)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:195)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Some write threads encountered unrecoverable errors: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Failed to write to table
Caused by: Access Denied: Table cloud-private-dev:test_bq.update_schema$20200710: User does not have bigquery.tables.updateData permission for table cloud-private-dev:test_bq.update_schema$20200710.; See logs for more detail
at com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor.maybeThrowEncounteredErrors(KCBQThreadPoolExecutor.java:110)
at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.put(BigQuerySinkTask.java:291)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:558)
... 10 more"
```