### PR TITLE
CC-9208: Include original trace in worker trace when task fails. (#18)

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -184,6 +184,7 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
+    // Periodically poll for errors here instead of doing a stop-the-world check in flush()
     executor.maybeThrowEncounteredErrors();
 
     logger.info("Putting {} records in the sink.", records.size());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -184,10 +184,7 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
-    // check for non-retriable errors and fail the task if any.
-    // adding this because any Exception thrown in flush will be ignored by the framework, which
-    // causes the connector to retry inserting the same batch of records.
-    executor.maybeFail();
+    executor.maybeThrowEncounteredErrors();
 
     logger.info("Putting {} records in the sink.", records.size());
     // create tableWriters

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -61,4 +61,10 @@ public class BigQueryConnectException extends ConnectException {
     }
     return messageBuilder.toString();
   }
+
+  @Override
+  public String toString() {
+    return getCause() != null ?
+        super.toString() + "\nCaused by: " + getCause().getLocalizedMessage() : super.toString();
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -22,11 +22,11 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +84,10 @@ public class TableWriter implements Runnable {
           logger.warn("Could not write batch of size {} to BigQuery.", currentBatch.size(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
-            currentBatchSize = getNewBatchSize(currentBatchSize);
+            currentBatchSize = getNewBatchSize(currentBatchSize, err);
+          } else {
+            // Throw exception on write errors such as 403.
+            throw new BigQueryConnectException("Failed to write to table", err);
           }
         }
       }
@@ -104,10 +107,10 @@ public class TableWriter implements Runnable {
 
   }
 
-  private static int getNewBatchSize(int currentBatchSize) {
+  private static int getNewBatchSize(int currentBatchSize, Throwable err) {
     if (currentBatchSize == 1) {
       // todo correct exception type?
-      throw new ConnectException("Attempted to reduce batch size below 1.");
+      throw new BigQueryConnectException("Attempted to reduce batch size below 1.", err);
     }
     // round batch size up so we don't end up with a dangling 1 row at the end.
     return (int) Math.ceil(currentBatchSize / 2.0);


### PR DESCRIPTION
## Problem
In a few cases where tasks fail or they don't fail but keep retrying, the underlying error is not shown in worker trace, including but not limited to:
- Destination table has no schema
- Table partitioned by timestamp column instead of ingestion time
- Add required fields to an existing schema
- User does not have bigquery.tables.updateData permission

## Solution
Surface the underlying error.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
