### PR TITLE
Demote log level

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -187,7 +187,7 @@ public class BigQuerySinkTask extends SinkTask {
     // Periodically poll for errors here instead of doing a stop-the-world check in flush()
     executor.maybeThrowEncounteredErrors();
 
-    logger.info("Putting {} records in the sink.", records.size());
+    logger.debug("Putting {} records in the sink.", records.size());
     // create tableWriters
     Map<PartitionedTableId, TableWriterBuilder> tableWriterBuilders = new HashMap<>();
 


### PR DESCRIPTION
## Problem
This log spams our ES logs very heavily.

## Solution
Demote to debug. Already one in `181798e3b438b1`, but now will be hotfixed sooner.