### PR TITLE
RCCA-1483: Bump up ioConfluentVersion to 5.5.1 to include the latest kafka-connect-avro-converter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ project.ext {
     googleCloudVersion = '1.79.0'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
-    ioConfluentVersion = '5.5.0'
+    ioConfluentVersion = '5.5.1'
     junitVersion = '4.12'
     kafkaVersion = '2.5.0'
     kafkaScalaVersion = '2.12' // For integration testing only
@@ -213,7 +213,7 @@ project(':kcbq-connector') {
 
     javadoc {
         options.links 'http://docs.oracle.com/javase/8/docs/api/'
-        options.links 'http://docs.confluent.io/3.2.0/connect/javadocs/'
+        options.links 'http://docs.confluent.io/5.5.1/connect/javadocs/'
         options.links 'https://googleapis.dev/java/google-cloud-clients/0.97.0-alpha/'
         options.links 'https://kafka.apache.org/0100/javadoc/'
         options.links 'https://avro.apache.org/docs/1.8.1/api/java/'
@@ -288,7 +288,7 @@ project('kcbq-api') {
 
     javadoc {
         options.links 'http://docs.oracle.com/javase/8/docs/api/'
-        options.links 'http://docs.confluent.io/3.2.0/connect/javadocs/'
+        options.links 'http://docs.confluent.io/5.5.1/connect/javadocs/'
     }
 
     dependencies {
@@ -344,7 +344,7 @@ project('kcbq-confluent') {
 
     javadoc {
         options.links 'http://docs.oracle.com/javase/8/docs/api/'
-        options.links 'http://docs.confluent.io/3.2.0/connect/javadocs/'
+        options.links 'http://docs.confluent.io/5.5.1/connect/javadocs/'
     }
 
     dependencies {


### PR DESCRIPTION
## Problem

Current connector image uses an outdated `kafka-connect-avro-converter`:
```
./gradlew kcbq-confluent:dependencies |grep avro|grep conver
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
+--- io.confluent:kafka-connect-avro-converter:5.5.0
```

There are some cloud incidents, caused by old versions of `kafka-connect-avro-converter`.

## Solution

Bump up `ioConfluentVersion` to `5.5.1` so that `kafka-connect-avro-converter:5.5.1` is used.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
