### PR TITLE
MINOR: Fix integration test to use new datasets config property

### DIFF
--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -245,7 +245,7 @@ CONNECTOR_PROPS="$DOCKER_DIR/connect/properties/connector.properties"
 cp "$RESOURCES_DIR/connector-template.properties" "$CONNECTOR_PROPS"
 cat << EOF >> $CONNECTOR_PROPS
 project=$KCBQ_TEST_PROJECT
-datasets=.*=$KCBQ_TEST_DATASET
+defaultDataset=$KCBQ_TEST_DATASET
 gcsBucketName=$KCBQ_TEST_BUCKET
 gcsFolderName=$KCBQ_TEST_FOLDER
 topics=$test_topics


### PR DESCRIPTION
## Problem
The integration tests don't use the new `defaultDataset` config property and instead rely on the old `datasets` property.

## Solution
Update the integration tests to use the new property.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
N/A

## Test Strategy
Patch the integration test script, then run the integration test.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

Target 2.0.x (the earliest affected branch) and, after merging, port forward into master.