### PR TITLE
GH-27: Add allowSchemaUnionization config property

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -316,8 +316,9 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldName();
     boolean allowNewBQFields = config.getBoolean(config.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
     boolean allowReqFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
+    boolean allowSchemaUnionization = config.getBoolean(config.ALLOW_SCHEMA_UNIONIZATION_CONFIG);
     return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
-                             allowNewBQFields, allowReqFieldRelaxation,
+                             allowNewBQFields, allowReqFieldRelaxation, allowSchemaUnionization,
                              kafkaKeyFieldName, kafkaDataFieldName,
                              timestampPartitionFieldName, clusteringFieldName);
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -217,27 +217,35 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String TABLE_CREATE_DOC =
           "Automatically create BigQuery tables if they don't already exist";
 
-  public static final String AUTO_CREATE_BUCKET_CONFIG =                "autoCreateBucket";
-  private static final ConfigDef.Type AUTO_CREATE_BUCKET_TYPE =          ConfigDef.Type.BOOLEAN;
-  public static final Boolean AUTO_CREATE_BUCKET_DEFAULT =                true;
+  public static final String AUTO_CREATE_BUCKET_CONFIG =                    "autoCreateBucket";
+  private static final ConfigDef.Type AUTO_CREATE_BUCKET_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final Boolean AUTO_CREATE_BUCKET_DEFAULT =                  true;
   private static final ConfigDef.Importance AUTO_CREATE_BUCKET_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String AUTO_CREATE_BUCKET_DOC =
           "Whether to automatically create the given bucket, if it does not exist. " +
                   "Only relevant if enableBatchLoad is configured.";
 
-  public static final String ALLOW_NEW_BIGQUERY_FIELDS_CONFIG =                 "allowNewBigQueryFields";
-  private static final ConfigDef.Type ALLOW_NEW_BIGQUERY_FIELDS_TYPE =          ConfigDef.Type.BOOLEAN;
-  public static final Boolean ALLOW_NEW_BIGQUERY_FIELDS_DEFAULT =               false;
+  public static final String ALLOW_NEW_BIGQUERY_FIELDS_CONFIG =                    "allowNewBigQueryFields";
+  private static final ConfigDef.Type ALLOW_NEW_BIGQUERY_FIELDS_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final Boolean ALLOW_NEW_BIGQUERY_FIELDS_DEFAULT =                  false;
   private static final ConfigDef.Importance ALLOW_NEW_BIGQUERY_FIELDS_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String ALLOW_NEW_BIGQUERY_FIELDS_DOC =
           "If true, new fields can be added to BigQuery tables during subsequent schema updates";
 
-  public static final String ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG =   "allowBigQueryRequiredFieldRelaxation";
-  private static final ConfigDef.Type ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_TYPE = ConfigDef.Type.BOOLEAN;
-  public static final Boolean ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_DEFAULT =      false;
+  public static final String ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG =                    "allowBigQueryRequiredFieldRelaxation";
+  private static final ConfigDef.Type ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final Boolean ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_DEFAULT =                  false;
   private static final ConfigDef.Importance ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_DOC =
           "If true, fields in BigQuery Schema can be changed from REQUIRED to NULLABLE";
+
+  public static final String ALLOW_SCHEMA_UNIONIZATION_CONFIG =                    "allowSchemaUnionization";
+  private static final ConfigDef.Type ALLOW_SCHEMA_UNIONIZATION_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final Boolean ALLOW_SCHEMA_UNIONIZATION_DEFAULT =                  false;
+  private static final ConfigDef.Importance ALLOW_SCHEMA_UNIONIZATION_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String ALLOW_SCHEMA_UNIONIZATION_DOC =
+          "If true, the existing table schema (if one is present) will be unionized with new "
+              + "record schemas during schema updates";
 
   public static final String UPSERT_ENABLED_CONFIG =                    "upsertEnabled";
   private static final ConfigDef.Type UPSERT_ENABLED_TYPE =             ConfigDef.Type.BOOLEAN;
@@ -435,6 +443,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_DEFAULT,
             ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_IMPORTANCE,
             ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_DOC
+        ).define(
+            ALLOW_SCHEMA_UNIONIZATION_CONFIG,
+            ALLOW_SCHEMA_UNIONIZATION_TYPE,
+            ALLOW_SCHEMA_UNIONIZATION_DEFAULT,
+            ALLOW_SCHEMA_UNIONIZATION_IMPORTANCE,
+            ALLOW_SCHEMA_UNIONIZATION_DOC
         ).define(
             UPSERT_ENABLED_CONFIG,
             UPSERT_ENABLED_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -35,6 +35,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,14 +106,14 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
       // Should only perform one schema update attempt.
       if (writeResponse.hasErrors()
               && onlyContainsInvalidSchemaErrors(writeResponse.getInsertErrors())) {
-        attemptSchemaUpdate(tableId, rows.keySet());
+        attemptSchemaUpdate(tableId, new ArrayList<>(rows.keySet()));
       }
     } catch (BigQueryException exception) {
       // Should only perform one table creation attempt.
       if (isTableNotExistedException(exception) && autoCreateTables) {
-        attemptTableCreate(tableId.getBaseTableId(), rows.keySet());
+        attemptTableCreate(tableId.getBaseTableId(), new ArrayList<>(rows.keySet()));
       } else if (isTableMissingSchema(exception)) {
-        attemptSchemaUpdate(tableId, rows.keySet());
+        attemptSchemaUpdate(tableId, new ArrayList<>(rows.keySet()));
       } else {
         throw exception;
       }
@@ -152,7 +153,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     return new HashMap<>();
   }
 
-  protected void attemptSchemaUpdate(PartitionedTableId tableId, Set<SinkRecord> records) {
+  protected void attemptSchemaUpdate(PartitionedTableId tableId, List<SinkRecord> records) {
     try {
       schemaManager.updateSchema(tableId.getBaseTableId(), records);
     } catch (BigQueryException exception) {
@@ -161,7 +162,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     }
   }
 
-  protected void attemptTableCreate(TableId tableId, Set<SinkRecord> records) {
+  protected void attemptTableCreate(TableId tableId, List<SinkRecord> records) {
     try {
       schemaManager.createTable(tableId, records);
     } catch (BigQueryException exception) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -40,11 +40,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.SortedMap;
 
 /**
@@ -118,7 +119,7 @@ public class GCSToBQWriter {
     // Check if the table specified exists
     // This error shouldn't be thrown. All tables should be created by the connector at startup
     if (autoCreateTables && bigQuery.getTable(tableId) == null) {
-      attemptTableCreate(tableId, rows.keySet());
+      attemptTableCreate(tableId, new ArrayList<>(rows.keySet()));
     }
 
     int attemptCount = 0;
@@ -198,7 +199,7 @@ public class GCSToBQWriter {
     Thread.sleep(retryWaitMs + random.nextInt(WAIT_MAX_JITTER));
   }
 
-  private void attemptTableCreate(TableId tableId, Set<SinkRecord> records) {
+  private void attemptTableCreate(TableId tableId, List<SinkRecord> records) {
     try {
       logger.info("Table {} does not exist, auto-creating table ", tableId);
       schemaManager.createTable(tableId, records);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -26,9 +26,8 @@ import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Future;
 
 public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
 
@@ -64,7 +63,7 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
   }
 
   @Override
-  protected void attemptSchemaUpdate(PartitionedTableId tableId, Set<SinkRecord> records) {
+  protected void attemptSchemaUpdate(PartitionedTableId tableId, List<SinkRecord> records) {
     // Update the intermediate table here...
     super.attemptSchemaUpdate(tableId, records);
     try {
@@ -77,7 +76,7 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
   }
 
   @Override
-  protected void attemptTableCreate(TableId tableId, Set<SinkRecord> records) {
+  protected void attemptTableCreate(TableId tableId, List<SinkRecord> records) {
     // Create the intermediate table here...
     super.attemptTableCreate(tableId, records);
     if (autoCreateTables) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -25,21 +25,29 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import org.apache.kafka.connect.data.Schema;
 
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.stubbing.OngoingStubbing;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class SchemaManagerTest {
 
@@ -123,5 +131,249 @@ public class SchemaManagerTest {
     Assert.assertEquals("The field name does not match the field name of time partition",
         testField.get(),
         definition.getClustering().getFields());
+  }
+
+  @Test
+  public void testSuccessfulUpdateWithOnlyRelaxedFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema relaxedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(false, true, false);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, relaxedSchema, relaxedSchema);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testDisallowedUpdateWithOnlyRelaxedFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema relaxedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, relaxedSchema, null);
+  }
+
+  @Test
+  public void testSuccessfulUpdateWithOnlyNewFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, expandedSchema);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testDisallowedUpdateWithOnlyNewFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(false, true, false);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, null);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testDisallowedUpdateWithOnlyNewRequiredFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, null);
+  }
+
+  @Test
+  public void testSuccessfulUpdateWithNewAndRelaxedFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedAndRelaxedSchema = com.google.cloud.bigquery.Schema.of(
+        // Relax an existing field from required to nullable
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        // Add a new nullable field
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build(),
+        // Add a new required field (that should be relaxed to nullable automatically)
+        Field.newBuilder("f3", LegacySQLTypeName.NUMERIC).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expectedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f3", LegacySQLTypeName.NUMERIC).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, true, false);
+
+    testGetAndValidateProposedSchema
+        (schemaManager, existingSchema, expandedAndRelaxedSchema, expectedSchema);
+  }
+
+  @Test
+  public void testSuccessfulUnionizedUpdateWithNewAndRelaxedFields() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema disjointSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expectedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, true, true);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, disjointSchema, expectedSchema);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testDisallowedUnionizedUpdateWithNewField() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(false, true, true);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, null);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testDisallowedUnionizedUpdateWithRelaxedField() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, true);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, null);
+  }
+
+  @Test
+  public void testUnionizedUpdateWithMultipleSchemas() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema firstNewSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+    com.google.cloud.bigquery.Schema secondNewSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.REQUIRED).build()
+    );
+    com.google.cloud.bigquery.Schema thirdNewSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+    List<com.google.cloud.bigquery.Schema> newSchemas =
+        Arrays.asList(firstNewSchema, secondNewSchema, thirdNewSchema);
+
+    com.google.cloud.bigquery.Schema expectedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, true, true);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, newSchemas, expectedSchema);
+  }
+
+  private SchemaManager createSchemaManager(
+      boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization) {
+    return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
+        allowNewFields, allowFieldRelaxation, allowUnionization,
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private void testGetAndValidateProposedSchema(
+      SchemaManager schemaManager,
+      com.google.cloud.bigquery.Schema existingSchema,
+      com.google.cloud.bigquery.Schema newSchema,
+      com.google.cloud.bigquery.Schema expectedSchema) {
+    testGetAndValidateProposedSchema(
+        schemaManager, existingSchema, Collections.singletonList(newSchema), expectedSchema);
+  }
+
+  private void testGetAndValidateProposedSchema(
+      SchemaManager schemaManager,
+      com.google.cloud.bigquery.Schema existingSchema,
+      List<com.google.cloud.bigquery.Schema> newSchemas,
+      com.google.cloud.bigquery.Schema expectedSchema) {
+    Table existingTable = existingSchema != null ? tableWithSchema(existingSchema) : null;
+
+    SinkRecord mockSinkRecord = recordWithValueSchema(mockKafkaSchema);
+    List<SinkRecord> incomingSinkRecords = Collections.nCopies(newSchemas.size(), mockSinkRecord);
+
+    when(mockBigQuery.getTable(tableId)).thenReturn(existingTable);
+    OngoingStubbing<com.google.cloud.bigquery.Schema> converterStub =
+        when(mockSchemaConverter.convertSchema(mockKafkaSchema));
+    for (com.google.cloud.bigquery.Schema newSchema : newSchemas) {
+      // The converter will return the schemas in the order that they are provided to it with the
+      // call to "thenReturn"
+      converterStub = converterStub.thenReturn(newSchema);
+    }
+
+    com.google.cloud.bigquery.Schema proposedSchema =
+        schemaManager.getAndValidateProposedSchema(tableId, incomingSinkRecords);
+
+    if (expectedSchema != null) {
+      Assert.assertEquals(expectedSchema, proposedSchema);
+    }
+  }
+
+  private Table tableWithSchema(com.google.cloud.bigquery.Schema schema) {
+    TableDefinition definition = mock(TableDefinition.class);
+    when(definition.getSchema()).thenReturn(schema);
+
+    Table result = mock(Table.class);
+    when(result.getDefinition()).thenReturn(definition);
+
+    return result;
+  }
+
+  private SinkRecord recordWithValueSchema(Schema valueSchema) {
+    SinkRecord result = mock(SinkRecord.class);
+    when(result.valueSchema()).thenReturn(valueSchema);
+    return result;
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -70,7 +70,7 @@ public class SchemaManagerTest {
     Optional<String> kafkaKeyFieldName = Optional.of("kafkaKey");
     Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, kafkaKeyFieldName, kafkaDataFieldName, Optional.empty(), Optional.empty());
+        mockBigQuery, false, false, false, kafkaKeyFieldName, kafkaDataFieldName, Optional.empty(), Optional.empty());
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -88,7 +88,7 @@ public class SchemaManagerTest {
   public void testTimestampPartitionSet() {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty());
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty());
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -108,7 +108,7 @@ public class SchemaManagerTest {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField);
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);


### PR DESCRIPTION
Addresses #27 by adding an `allowSchemaUnionization` config property that defaults to `false` and dictates whether schema unionization should occur during schema updates. Unit tests for the `SchemaManager` class (where the bulk of this logic is located) are added to verify expected behavior.