### PR TITLE
MINOR: Fix BigQueryWriterTest unit test

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -116,8 +116,7 @@ public class BigQueryWriterTest {
     when(insertAllResponse.hasErrors()).thenReturn(false);
     when(insertAllResponse.getInsertErrors()).thenReturn(emptyMap);
 
-    BigQueryException missTableException = mock(BigQueryException.class);
-    when(missTableException.getCode()).thenReturn(404);
+    BigQueryException missTableException = new BigQueryException(404, "Table is missing");
 
     when(bigQuery.insertAll(anyObject())).thenThrow(missTableException).thenReturn(insertAllResponse);
 
@@ -151,8 +150,7 @@ public class BigQueryWriterTest {
     when(insertAllResponse.hasErrors()).thenReturn(false);
     when(insertAllResponse.getInsertErrors()).thenReturn(emptyMap);
 
-    BigQueryException missTableException = mock(BigQueryException.class);
-    when(missTableException.getCode()).thenReturn(404);
+    BigQueryException missTableException = new BigQueryException(404, "Table is missing");
 
     when(bigQuery.insertAll(anyObject())).thenThrow(missTableException).thenReturn(insertAllResponse);
 


### PR DESCRIPTION
This mimics a [change made on 2.0.x](https://github.com/confluentinc/kafka-connect-bigquery/blob/3aec4fd720d2a1cacd77ed2250addcd7d7d9df10/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java#L124); should have been applied back onto 1.6.x. Doing so here to fix the build.