### PR TITLE
GH-39: Fix NPE when null inner values are encountered with field sanitization enabled

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -1,5 +1,6 @@
 package com.wepay.kafka.connect.bigquery.utils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -20,15 +21,17 @@ public class FieldNameSanitizer {
   // letters, numbers, and underscores.
   // Note: a.b and a/b will have the same value after sanitization which will cause Duplicate key
   // Exception.
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> replaceInvalidKeys(Map<String, Object> map) {
-    return map.entrySet().stream().collect(Collectors.toMap(
-        (entry) -> sanitizeName(entry.getKey()),
-        (entry) -> {
-          if (entry.getValue() instanceof Map) {
-            return replaceInvalidKeys((Map<String, Object>) entry.getValue());
-          }
-          return entry.getValue();
-        }
-    ));
+    Map<String, Object> result = new HashMap<>();
+    map.forEach((key, value) -> {
+      String sanitizedKey = sanitizeName(key);
+      if (value instanceof Map) {
+        result.put(sanitizedKey, replaceInvalidKeys((Map<String, Object>) value));
+      } else {
+        result.put(sanitizedKey, value);
+      }
+    });
+    return result;
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
@@ -1,5 +1,6 @@
 package com.wepay.kafka.connect.bigquery.utils;
 
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,5 +75,27 @@ public class FieldNameSanitizerTest {
 
     // Validate map size.
     assertEquals(5, sanitizedMap.size());
+  }
+
+  /**
+   * Verifies that null values are acceptable while sanitizing keys.
+   */
+  @Test
+  public void testNullValue() {
+    assertEquals(
+        Collections.singletonMap("abc", null),
+        FieldNameSanitizer.replaceInvalidKeys(Collections.singletonMap("abc", null)));
+  }
+
+  @Test
+  public void testDeeplyNestedNullValues() {
+    testMap = new HashMap<>();
+    testMap.put("top", null);
+    testMap.put("middle", Collections.singletonMap("key", null));
+    testMap.put("bottom", Collections.singletonMap("key", Collections.singletonMap("key", null)));
+    assertEquals(
+        testMap,
+        FieldNameSanitizer.replaceInvalidKeys(testMap)
+    );
   }
 }


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/39, by converting Java 8 streams to a simpler `Map::forEach` invocation. Adds two tests to verify that null inner values (even if nested deeply) do not cause any issues with sanitization, and the existing tests provide sufficient coverage to give us confidence that the changes here don't break the other parts of the field sanitization logic.