### PR TITLE
GH-41: Fix concurrent integration test runs on Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ used.
 
 ```bash
 # (Re)builds the project and runs the integration tests, skipping unit tests to save a bit of time
-mvn clean package failsafe:integration-test@embedded-integration-test -Dskip.unit.tests=true
+mvn clean package integration-test -Dskip.unit.tests=true
 ```
 
 ### How Integration Testing Works

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -42,7 +42,6 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.Table;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.wepay.kafka.connect.bigquery.BigQueryHelper;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
@@ -140,15 +139,6 @@ public abstract class BaseConnectorIT {
     result.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource());
 
     result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-
-    String suffix = tableSuffix();
-    if (!suffix.isEmpty()) {
-      String escapedSuffix = suffix.replaceAll("\\\\", "\\\\\\\\").replaceAll("\\$", "\\\\\\$");
-      result.put("transforms", "addSuffix");
-      result.put("transforms.addSuffix.type", "org.apache.kafka.connect.transforms.RegexRouter");
-      result.put("transforms.addSuffix.regex", "(.*)");
-      result.put("transforms.addSuffix.replacement", "$1" + escapedSuffix);
-    }
 
     return result;
   }
@@ -337,8 +327,8 @@ public abstract class BaseConnectorIT {
     }
   }
 
-  protected String suffixedTable(String table) {
-    return table + tableSuffix();
+  protected String suffixedTableOrTopic(String tableOrTopic) {
+    return tableOrTopic + tableSuffix();
   }
 
   protected String sanitizedTable(String table) {
@@ -346,7 +336,7 @@ public abstract class BaseConnectorIT {
   }
 
   protected String suffixedAndSanitizedTable(String table) {
-    return sanitizedTable(suffixedTable(table));
+    return sanitizedTable(suffixedTableOrTopic(table));
   }
 
   private String readEnvVar(String var) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -46,6 +46,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.wepay.kafka.connect.bigquery.BigQueryHelper;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -137,6 +138,8 @@ public abstract class BaseConnectorIT {
     result.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset());
     result.put(BigQuerySinkConfig.KEYFILE_CONFIG, keyFile());
     result.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource());
+
+    result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
 
     String suffix = tableSuffix();
     if (!suffix.isEmpty()) {
@@ -334,8 +337,16 @@ public abstract class BaseConnectorIT {
     }
   }
 
-  protected String suffixedTableName(String table) {
+  protected String suffixedTable(String table) {
     return table + tableSuffix();
+  }
+
+  protected String sanitizedTable(String table) {
+    return FieldNameSanitizer.sanitizeName(table);
+  }
+
+  protected String suffixedAndSanitizedTable(String table) {
+    return sanitizedTable(suffixedTable(table));
   }
 
   private String readEnvVar(String var) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
@@ -287,7 +287,8 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
   private void verify(String testCase, List<List<Object>> expectedRows) {
     List<List<Object>> testRows;
     try {
-      testRows = readAllRows(newBigQuery(), TEST_CASE_PREFIX + FieldNameSanitizer.sanitizeName(testCase), "row");
+      String table = suffixedTableName(TEST_CASE_PREFIX + FieldNameSanitizer.sanitizeName(testCase));
+      testRows = readAllRows(newBigQuery(), table, "row");
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
@@ -169,8 +169,11 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
 
   @Before
   public void setup() throws Exception {
-    BucketClearer.clearBucket(keyFile(), project(), gcsBucket(), keySource());
-    TableClearer.clearTables(newBigQuery(), dataset(), TEST_TABLES);
+    Collection<String> suffixedTables = TEST_TABLES.stream()
+        .map(this::suffixedTableName)
+        .collect(Collectors.toSet());
+    BucketClearer.clearBucket(keyFile(), project(), gcsBucket(), gcsFolder(), keySource());
+    TableClearer.clearTables(newBigQuery(), dataset(), suffixedTables);
 
     startConnect();
     restApp = new RestApp(
@@ -272,7 +275,7 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
     result.put(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, "true");
     result.put(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, "true");
     result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-    result.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, "kcbq_test_gcs-load");
+    result.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, suffixedTableName("kcbq_test_gcs-load"));
     result.put(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG, "10");
     result.put(BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG, gcsBucket());
     result.put(BigQuerySinkConfig.GCS_FOLDER_NAME_CONFIG, gcsFolder());

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
@@ -158,10 +158,6 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
       .map(tc -> TEST_CASE_PREFIX + tc)
       .collect(Collectors.toList());
 
-  private static final Collection<String> TEST_TABLES = TEST_TOPICS.stream()
-      .map(FieldNameSanitizer::sanitizeName)
-      .collect(Collectors.toList());
-
   private RestApp restApp;
   private String schemaRegistryUrl;
   private Producer<byte[], byte[]> valueProducer;
@@ -169,11 +165,11 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
 
   @Before
   public void setup() throws Exception {
-    Collection<String> suffixedTables = TEST_TABLES.stream()
-        .map(this::suffixedTableName)
+    Collection<String> tables = TEST_TOPICS.stream()
+        .map(this::suffixedAndSanitizedTable)
         .collect(Collectors.toSet());
     BucketClearer.clearBucket(keyFile(), project(), gcsBucket(), gcsFolder(), keySource());
-    TableClearer.clearTables(newBigQuery(), dataset(), suffixedTables);
+    TableClearer.clearTables(newBigQuery(), dataset(), tables);
 
     startConnect();
     restApp = new RestApp(
@@ -275,7 +271,7 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
     result.put(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, "true");
     result.put(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, "true");
     result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-    result.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, suffixedTableName("kcbq_test_gcs-load"));
+    result.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, suffixedAndSanitizedTable("kcbq_test_gcs-load"));
     result.put(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG, "10");
     result.put(BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG, gcsBucket());
     result.put(BigQuerySinkConfig.GCS_FOLDER_NAME_CONFIG, gcsFolder());
@@ -287,7 +283,7 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
   private void verify(String testCase, List<List<Object>> expectedRows) {
     List<List<Object>> testRows;
     try {
-      String table = suffixedTableName(TEST_CASE_PREFIX + FieldNameSanitizer.sanitizeName(testCase));
+      String table = suffixedAndSanitizedTable(TEST_CASE_PREFIX + FieldNameSanitizer.sanitizeName(testCase));
       testRows = readAllRows(newBigQuery(), table, "row");
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
@@ -270,12 +270,20 @@ public class BigQuerySinkConnectorIT extends BaseConnectorIT {
     
     result.put(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, "true");
     result.put(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, "true");
-    result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
     result.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, suffixedAndSanitizedTable("kcbq_test_gcs-load"));
     result.put(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG, "10");
     result.put(BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG, gcsBucket());
     result.put(BigQuerySinkConfig.GCS_FOLDER_NAME_CONFIG, gcsFolder());
     result.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+
+    String suffix = tableSuffix();
+    if (!suffix.isEmpty()) {
+      String escapedSuffix = suffix.replaceAll("\\\\", "\\\\\\\\").replaceAll("\\$", "\\\\\\$");
+      result.put("transforms", "addSuffix");
+      result.put("transforms.addSuffix.type", "org.apache.kafka.connect.transforms.RegexRouter");
+      result.put("transforms.addSuffix.regex", "(.*)");
+      result.put("transforms.addSuffix.replacement", "$1" + escapedSuffix);
+    }
 
     return result;
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -116,8 +116,8 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = "test_upsert";
-    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
+    final String table = suffixedTableName("test_upsert");
+    TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -171,8 +171,8 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = "test_delete";
-    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
+    final String table = suffixedTableName("test_delete");
+    TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -230,8 +230,8 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = "test_upsert_delete";
-    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
+    final String table = suffixedTableName("test_upsert_delete");
+    TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -293,8 +293,8 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     final String topic = "test-upsert-delete-throughput";
     connect.kafka().createTopic(topic, numPartitions);
 
-    final String table = "test_upsert_delete_throughput";
-    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
+    final String table = suffixedTableName("test_upsert_delete_throughput");
+    TableClearer.clearTables(bigQuery, dataset(), table);
 
     // Instantiate the converters we'll use to send records to the connector
     Converter keyConverter = converter(true);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -116,7 +116,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedTableName("test_upsert");
+    final String table = suffixedAndSanitizedTable("test_upsert");
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -171,7 +171,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedTableName("test_delete");
+    final String table = suffixedAndSanitizedTable("test_delete");
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -230,7 +230,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedTableName("test_upsert_delete");
+    final String table = suffixedAndSanitizedTable("test_upsert_delete");
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -293,7 +293,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     final String topic = "test-upsert-delete-throughput";
     connect.kafka().createTopic(topic, numPartitions);
 
-    final String table = suffixedTableName("test_upsert_delete_throughput");
+    final String table = suffixedAndSanitizedTable("test_upsert_delete_throughput");
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // Instantiate the converters we'll use to send records to the connector

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -21,6 +21,7 @@ package com.wepay.kafka.connect.bigquery.integration;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.connect.data.Schema;
@@ -116,7 +117,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     connect.kafka().createTopic(topic, TASKS_MAX);
 
     final String table = "test_upsert";
-    clearPriorTable(bigQuery, table);
+    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -171,7 +172,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     connect.kafka().createTopic(topic, TASKS_MAX);
 
     final String table = "test_delete";
-    clearPriorTable(bigQuery, table);
+    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -230,7 +231,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     connect.kafka().createTopic(topic, TASKS_MAX);
 
     final String table = "test_upsert_delete";
-    clearPriorTable(bigQuery, table);
+    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
 
     // setup props for the sink connector
     Map<String, String> props = baseConnectorProps(TASKS_MAX);
@@ -293,7 +294,7 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     connect.kafka().createTopic(topic, numPartitions);
 
     final String table = "test_upsert_delete_throughput";
-    clearPriorTable(bigQuery, table);
+    TableClearer.clearTables(bigQuery, dataset(), suffixedTableName(table));
 
     // Instantiate the converters we'll use to send records to the connector
     Converter keyConverter = converter(true);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -112,11 +112,11 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testUpsert() throws Throwable {
     // create topic in Kafka
-    final String topic = "test-upsert";
+    final String topic = suffixedTableOrTopic("test-upsert");
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedAndSanitizedTable("test_upsert");
+    final String table = sanitizedTable(topic);
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -167,11 +167,11 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testDelete() throws Throwable {
     // create topic in Kafka
-    final String topic = "test-delete";
+    final String topic = suffixedTableOrTopic("test-delete");
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedAndSanitizedTable("test_delete");
+    final String table = sanitizedTable(topic);
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -226,11 +226,11 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testUpsertDelete() throws Throwable {
     // create topic in Kafka
-    final String topic = "test-upsert-delete";
+    final String topic = suffixedTableOrTopic("test-upsert-delete");
     // Make sure each task gets to read from at least one partition
     connect.kafka().createTopic(topic, TASKS_MAX);
 
-    final String table = suffixedAndSanitizedTable("test_upsert_delete");
+    final String table = sanitizedTable(topic);
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // setup props for the sink connector
@@ -290,10 +290,10 @@ public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
     final int tasksMax = 1;
 
     // create topic in Kafka
-    final String topic = "test-upsert-delete-throughput";
+    final String topic = suffixedTableOrTopic("test-upsert-delete-throughput");
     connect.kafka().createTopic(topic, numPartitions);
 
-    final String table = suffixedAndSanitizedTable("test_upsert_delete_throughput");
+    final String table = sanitizedTable(topic);
     TableClearer.clearTables(bigQuery, dataset(), table);
 
     // Instantiate the converters we'll use to send records to the connector

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/TableClearer.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/TableClearer.java
@@ -33,7 +33,6 @@ import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.table;
 public class TableClearer {
   private static final Logger logger = LoggerFactory.getLogger(TableClearer.class);
 
-  // TODO: Might want to add support for table sanitization here
   /**
    * Clear out one or more BigQuery tables. Useful in integration testing to provide a clean slate
    * before creating a connector and writing to those tables.

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/TableClearer.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/TableClearer.java
@@ -25,6 +25,7 @@ import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.table;
@@ -49,5 +50,16 @@ public class TableClearer {
         logger.info("{} does not exist", table(table));
       }
     }
+  }
+
+  /**
+   * Clear out one or more BigQuery tables. Useful in integration testing to provide a clean slate
+   * before creating a connector and writing to those tables.
+   * @param bigQuery The BigQuery client to use when sending table deletion requests.
+   * @param dataset The dataset that the to-be-cleared tables belong to.
+   * @param tables The tables to clear.
+   */
+  public static void clearTables(BigQuery bigQuery, String dataset, String... tables) {
+    clearTables(bigQuery, dataset, Arrays.asList(tables));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,8 @@ under the License.
                                     <KCBQ_TEST_PROJECT>connect-205118</KCBQ_TEST_PROJECT>
                                     <KCBQ_TEST_DATASET>jenkinsKcbqIntegrationTesting</KCBQ_TEST_DATASET>
                                     <KCBQ_TEST_BUCKET>jenkins-kcbq-integration-testing</KCBQ_TEST_BUCKET>
-                                    <KCBQ_TEST_TABLE_SUFFIX>_${scmBranch}_${buildNumber}_${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
-                                    <KCBQ_TEST_FOLDER>${scmBranch}_${buildNumber}_${timestamp}</KCBQ_TEST_FOLDER>
+                                    <KCBQ_TEST_TABLE_SUFFIX>-${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
+                                    <KCBQ_TEST_FOLDER>${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_FOLDER>
                                 </environmentVariables>
                             </configuration>
                         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,8 @@ under the License.
                                     <KCBQ_TEST_PROJECT>connect-205118</KCBQ_TEST_PROJECT>
                                     <KCBQ_TEST_DATASET>jenkinsKcbqIntegrationTesting</KCBQ_TEST_DATASET>
                                     <KCBQ_TEST_BUCKET>jenkins-kcbq-integration-testing</KCBQ_TEST_BUCKET>
-                                    <KCBQ_TEST_TABLE_SUFFIX>-${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
-                                    <KCBQ_TEST_FOLDER>${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_FOLDER>
+                                    <KCBQ_TEST_TABLE_SUFFIX>_${scmBranch}_${buildNumber}_${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
+                                    <KCBQ_TEST_FOLDER>${scmBranch}_${buildNumber}_${timestamp}</KCBQ_TEST_FOLDER>
                                 </environmentVariables>
                             </configuration>
                         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -326,9 +326,7 @@ under the License.
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.plugin.version}</version>
                     <configuration>
-                        <excludes>
-                            <exclude>**/*IT.java</exclude>
-                        </excludes>
+                        <excludedGroups>org.apache.kafka.test.IntegrationTest</excludedGroups>
                         <skip>${skip.unit.tests}</skip>
                     </configuration>
                 </plugin>
@@ -343,9 +341,7 @@ under the License.
                                 <goal>integration-test</goal>
                             </goals>
                             <configuration>
-                                <includes>
-                                    <include>**/*IT.java</include>
-                                </includes>
+                                <groups>org.apache.kafka.test.IntegrationTest</groups>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <junit.version>4.12</junit.version>
         <mockito.version>3.2.4</mockito.version>
 
+        <buildnumber.plugin.version>1.4</buildnumber.plugin.version>
         <checkstyle.plugin.version>2.15</checkstyle.plugin.version>
         <checkstyle.version>6.18</checkstyle.version>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
@@ -415,6 +416,22 @@ under the License.
         <profile>
             <id>jenkins</id>
             <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>buildnumber-maven-plugin</artifactId>
+                        <version>${buildnumber.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-test-suffix</id>
+                                <goals>
+                                    <goal>create</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
                 <pluginManagement>
                     <plugins>
                         <plugin>
@@ -432,6 +449,8 @@ under the License.
                                     <KCBQ_TEST_PROJECT>connect-205118</KCBQ_TEST_PROJECT>
                                     <KCBQ_TEST_DATASET>jenkinsKcbqIntegrationTesting</KCBQ_TEST_DATASET>
                                     <KCBQ_TEST_BUCKET>jenkins-kcbq-integration-testing</KCBQ_TEST_BUCKET>
+                                    <KCBQ_TEST_TABLE_SUFFIX>-${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
+                                    <KCBQ_TEST_FOLDER>${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_FOLDER>
                                 </environmentVariables>
                             </configuration>
                         </plugin>


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/41, with the strategy proposed in the issue:

1. We've set a conservative retention policy of 24 hours on the dataset we use for integration testing the connector
2. We've altered the integration tests for the connector to use an optional `$KCBQ_TEST_TABLE_SUFFIX` environment variable which, if present, is appended to the end of each table created during integration tests
3. We've modified the Jenkins profile in the top-level pom to populate that environment variable and `$KCBQ_TEST_FOLDER` with the branch name, git commit hash, epoch timestamp for the run, so that we can easily identify which test runs correspond to which tables in the event that there's a failure we'd like to investigate