### PR TITLE
CC-12157: Throw nicer exception on detecting cycle in schema

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -20,10 +20,12 @@
 package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 
+import com.google.common.collect.ImmutableList;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -33,6 +35,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Timestamp;
 
 import org.junit.Test;
+
+import io.confluent.connect.avro.AvroData;
 
 public class BigQuerySchemaConverterTest {
 
@@ -628,6 +632,43 @@ public class BigQuerySchemaConverterTest {
     com.google.cloud.bigquery.Schema bigQueryTestSchema =
         new BigQuerySchemaConverter(true).convertSchema(kafkaConnectTestSchema);
     assertEquals(bigQueryExpectedSchema, bigQueryTestSchema);
+  }
 
+  @Test
+  public void testSimpleRecursiveSchemaThrows() {
+    final String fieldName = "RecursiveField";
+
+    org.apache.avro.Schema recursiveAvroSchema = org.apache.avro.SchemaBuilder
+        .record("RecursiveItem")
+        .namespace("com.example")
+        .fields()
+        .name(fieldName)
+        .type().unionOf().nullType().and().type("RecursiveItem").endUnion()
+        .nullDefault()
+        .endRecord();
+    Schema connectSchema = new AvroData(100).toConnectSchema(recursiveAvroSchema);
+    ConversionConnectException e = assertThrows(ConversionConnectException.class, () ->
+        new BigQuerySchemaConverter(true).convertSchema(connectSchema));
+    assertEquals("Kafka Connect schema contains cycle", e.getMessage());
+  }
+
+  @Test
+  public void testComplexRecursiveSchemaThrows() {
+    final String fieldName = "RecursiveField";
+
+    org.apache.avro.Schema recursiveAvroSchema = org.apache.avro.SchemaBuilder
+        .record("RecursiveItem")
+        .namespace("com.example")
+        .fields()
+        .name(fieldName)
+        .type()
+            .array().items()
+                .map().values().type("RecursiveItem").noDefault()
+        .endRecord();
+
+    Schema connectSchema = new AvroData(100).toConnectSchema(recursiveAvroSchema);
+    ConversionConnectException e = assertThrows(ConversionConnectException.class, () ->
+        new BigQuerySchemaConverter(true).convertSchema(connectSchema));
+    assertEquals("Kafka Connect schema contains cycle", e.getMessage());
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -638,6 +638,7 @@ public class BigQuerySchemaConverterTest {
   public void testSimpleRecursiveSchemaThrows() {
     final String fieldName = "RecursiveField";
 
+    // Construct Avro schema with recursion since we cannot directly construct Connect schema with cycle
     org.apache.avro.Schema recursiveAvroSchema = org.apache.avro.SchemaBuilder
         .record("RecursiveItem")
         .namespace("com.example")
@@ -646,6 +647,7 @@ public class BigQuerySchemaConverterTest {
         .type().unionOf().nullType().and().type("RecursiveItem").endUnion()
         .nullDefault()
         .endRecord();
+
     Schema connectSchema = new AvroData(100).toConnectSchema(recursiveAvroSchema);
     ConversionConnectException e = assertThrows(ConversionConnectException.class, () ->
         new BigQuerySchemaConverter(true).convertSchema(connectSchema));
@@ -656,6 +658,7 @@ public class BigQuerySchemaConverterTest {
   public void testComplexRecursiveSchemaThrows() {
     final String fieldName = "RecursiveField";
 
+    // Construct Avro schema with recursion since we cannot directly construct Connect schema with cycle
     org.apache.avro.Schema recursiveAvroSchema = org.apache.avro.SchemaBuilder
         .record("RecursiveItem")
         .namespace("com.example")

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <kafka.version>2.5.0</kafka.version>
         <slf4j.version>1.7.26</slf4j.version>
 
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
         <mockito.version>3.2.4</mockito.version>
 
         <checkstyle.plugin.version>2.15</checkstyle.plugin.version>


### PR DESCRIPTION
The schema conversion doesn't handle schemas that contain recursive cycles. Rather than fail with a generic `StackOverflowError`, try to detect cycles and throw a `ConversionConnectException`.