### PR TITLE
MINOR: Catch 'request payload exceeds size' errors from BigQuery and reduce batch size in response

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -27,7 +27,6 @@ import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +43,7 @@ public class TableWriter implements Runnable {
 
   private static final int BAD_REQUEST_CODE = 400;
   private static final String INVALID_REASON = "invalid";
+  private static final String PAYLOAD_TOO_LARGE_REASON = "Request payload size exceeds the limit:";
 
   private final BigQueryWriter writer;
   private final PartitionedTableId table;
@@ -137,6 +137,10 @@ public class TableWriter implements Runnable {
        * 10MB. if this actually ever happens...
        * todo distinguish this from other invalids (like invalid table schema).
        */
+      return true;
+    } else if (exception.getCode() == BAD_REQUEST_CODE
+        && exception.getMessage() != null
+        && exception.getMessage().contains(PAYLOAD_TOO_LARGE_REASON)) {
       return true;
     }
     return false;


### PR DESCRIPTION
We've started seeing this exception in the logs for the connector:

```
[WARN] 2020-10-16 10:01:25,429 [pool-7-thread-8] com.wepay.kafka.connect.bigquery.write.batch.TableWriter run - Could not write batch of size 176 to BigQuery.
com.google.cloud.bigquery.BigQueryException: Request payload size exceeds the limit: 10485760 bytes.
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:103)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:377)
	at com.google.cloud.bigquery.BigQueryImpl$21.call(BigQueryImpl.java:773)
	at com.google.cloud.bigquery.BigQueryImpl$21.call(BigQueryImpl.java:770)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.bigquery.BigQueryImpl.insertAll(BigQueryImpl.java:769)
	at com.wepay.kafka.connect.bigquery.write.row.SimpleBigQueryWriter.performWriteRequest(SimpleBigQueryWriter.java:67)
	at com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter.writeRows(BigQueryWriter.java:118)
	at com.wepay.kafka.connect.bigquery.write.batch.TableWriter.run(TableWriter.java:95)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Request payload size exceeds the limit: 10485760 bytes.",
    "reason" : "badRequest"
  } ],
  "message" : "Request payload size exceeds the limit: 10485760 bytes.",
  "status" : "INVALID_ARGUMENT"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:150)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:451)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1089)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:549)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:482)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:599)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:375)
```

It's not causing retries with a smaller batch at the moment, but looks like it should.