### PR TITLE
GH-50: Remove maybeEnsureExistingTable method

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -155,15 +155,6 @@ public class BigQuerySinkTask extends SinkTask {
     topicPartitionManager.resumeAll();
   }
 
-  private void maybeEnsureExistingTable(TableId table) {
-    BigQuery bigQuery = getBigQuery();
-    if (bigQuery.getTable(table) == null && !config.getBoolean(config.TABLE_CREATE_CONFIG)) {
-      throw new BigQueryConnectException("Table '" + table + "' does not exist. " +
-          "You may want to enable auto table creation by setting " + config.TABLE_CREATE_CONFIG
-          + "=true in the properties file");
-    }
-  }
-
   @Override
   public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
     if (upsertDelete) {
@@ -199,8 +190,6 @@ public class BigQuerySinkTask extends SinkTask {
       TableId intermediateTableId = mergeBatches.intermediateTableFor(baseTableId);
       // If upsert/delete is enabled, we want to stream into a non-partitioned intermediate table
       return new PartitionedTableId.Builder(intermediateTableId).build();
-    } else {
-      maybeEnsureExistingTable(baseTableId);
     }
 
     PartitionedTableId.Builder builder = new PartitionedTableId.Builder(baseTableId);


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/50.

We don't need to preemptively check for the existence of tables at all, as the end result will be the same regardless (the connector will fail if table creation is disabled and receives records destined for a table that does not already exist). The current preemptive check makes it extremely easy to run up against BigQuery rate limits, and the additional complexity of retaining the check with some kind of caching layer doesn't seem worth the benefit it provides, so right now I think it's best to just remove it altogether.