### PR TITLE
GH-52: Add link to Confluent-hosted docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://img.shields.io/codecov/c/github/wepay/kafka-connect-bigquery.svg?style=flat-square)](https://codecov.io/gh/wepay/kafka-connect-bigquery)
 
 This is an implementation of a sink connector from [Apache Kafka] to [Google BigQuery], built on top 
-of [Apache Kafka Connect]. For a comprehensive list of configuration options, see the [Connector Configuration Wiki].
+of [Apache Kafka Connect]. Documentation is [hosted by Confluent](https://docs.confluent.io/current/connect/kafka-connect-bigquery/index.html), and includes a [comprehensive list of configuration properties](https://docs.confluent.io/current/connect/kafka-connect-bigquery/kafka_connect_bigquery_config.html#kafka-connect-bigquery-config).
 
 ## Download
 
@@ -214,7 +214,6 @@ data must have a unique value for its row number (row numbers are one-indexed).
   [BigQuery]: https://cloud.google.com/bigquery/
   [boot2docker]: http://boot2docker.io
   [Confluent Platform]: http://docs.confluent.io/3.0.0/installation.html
-  [Connector Configuration Wiki]: https://github.com/wepay/kafka-connect-bigquery/wiki/Connector-Configuration
   [Docker Machine]: https://docs.docker.com/machine/
   [Docker]: https://www.docker.com
   [Google BigQuery]: https://cloud.google.com/bigquery/


### PR DESCRIPTION
We'll have to update the configuration docs before we push out the 2.0.0 release, but for now they should be up-to-date.