### PR TITLE
1.6.x backports

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -186,12 +186,10 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
-    // check for non-retriable errors and fail the task if any.
-    // adding this because any Exception thrown in flush will be ignored by the framework, which
-    // causes the connector to retry inserting the same batch of records.
-    executor.maybeFail();
+    // Periodically poll for errors here instead of doing a stop-the-world check in flush()
+    executor.maybeThrowEncounteredErrors();
 
-    logger.info("Putting {} records in the sink.", records.size());
+    logger.debug("Putting {} records in the sink.", records.size());
 
     // create tableWriters
     Map<PartitionedTableId, TableWriterBuilder> tableWriterBuilders = new HashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -186,6 +186,11 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
+    // check for non-retriable errors and fail the task if any.
+    // adding this because any Exception thrown in flush will be ignored by the framework, which
+    // causes the connector to retry inserting the same batch of records.
+    executor.maybeFail();
+
     logger.info("Putting {} records in the sink.", records.size());
 
     // create tableWriters

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -62,4 +62,10 @@ public class BigQueryConnectException extends ConnectException {
     }
     return messageBuilder.toString();
   }
+
+  @Override
+  public String toString() {
+    return getCause() != null ?
+        super.toString() + "\nCaused by: " + getCause().getLocalizedMessage() : super.toString();
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -45,7 +45,7 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   private static final Logger logger = LoggerFactory.getLogger(KCBQThreadPoolExecutor.class);
 
 
-  private ConcurrentHashMap.KeySetView<Throwable, Boolean> encounteredErrors =
+  private final ConcurrentHashMap.KeySetView<Throwable, Boolean> encounteredErrors =
       ConcurrentHashMap.newKeySet();
 
   /**
@@ -94,7 +94,6 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
     countDownLatch.await();
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
-      encounteredErrors.clear();
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
                                          + errorString + "; See logs for more detail");
     }
@@ -107,4 +106,26 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
                         .collect(Collectors.toList()));
     return String.join(", ", exceptionTypeStrings);
   }
+
+  private static String createDetailedErrorString(Collection<Throwable> errors) {
+    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
+    exceptionTypeStrings.addAll(errors.stream()
+        .map(throwable ->
+            throwable.getClass().getName() + "\nMessage: " + throwable.getLocalizedMessage())
+        .collect(Collectors.toList()));
+    return String.join(", ", exceptionTypeStrings);
+  }
+
+  /**
+   * Checks for BigQuery errors. No-op if there isn't any error.
+   *
+   * @throws BigQueryConnectException if there have been any unrecoverable errors when writing to BigQuery.
+   */
+  public void maybeFail() throws BigQueryConnectException {
+    if (encounteredErrors.size() > 0) {
+      throw new BigQueryConnectException("Encountered unrecoverable errors: "
+          + createDetailedErrorString(encounteredErrors) + "; See logs for more detail");
+    }
+  }
+
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -92,10 +92,25 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
       execute(new CountDownRunnable(countDownLatch));
     }
     countDownLatch.await();
+    maybeThrowEncounteredErrors();
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
                                          + errorString + "; See logs for more detail");
+    }
+  }
+
+  /**
+   * Immediately throw an exception if any unrecoverable errors were encountered by any of the write
+   * tasks.
+   *
+   * @throws BigQueryConnectException if any of the tasks failed.
+   */
+  public void maybeThrowEncounteredErrors() {
+    if (encounteredErrors.size() > 0) {
+      String errorString = createErrorString(encounteredErrors);
+      throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
+          + errorString + "; See logs for more detail");
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
@@ -85,7 +86,10 @@ public class TableWriter implements Runnable {
           logger.warn("Could not write batch of size {} to BigQuery.", currentBatch.size(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
-            currentBatchSize = getNewBatchSize(currentBatchSize);
+            currentBatchSize = getNewBatchSize(currentBatchSize, err);
+          } else {
+            // Throw exception on write errors such as 403.
+            throw new BigQueryConnectException("Failed to write to table", err);
           }
         }
       }
@@ -105,10 +109,10 @@ public class TableWriter implements Runnable {
 
   }
 
-  private static int getNewBatchSize(int currentBatchSize) {
+  private static int getNewBatchSize(int currentBatchSize, Throwable err) {
     if (currentBatchSize == 1) {
       // todo correct exception type?
-      throw new ConnectException("Attempted to reduce batch size below 1.");
+      throw new BigQueryConnectException("Attempted to reduce batch size below 1.", err);
     }
     // round batch size up so we don't end up with a dangling 1 row at the end.
     return (int) Math.ceil(currentBatchSize / 2.0);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -299,11 +299,43 @@ public class BigQuerySinkTaskTest {
         TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
-  // It's important that the buffer be completely wiped after a call to flush, since any execption
-  // thrown during flush causes Kafka Connect to not commit the offsets for any records sent to the
-  // task since the last flush
-  @Test
-  public void testBufferClearOnFlushError() {
+  @Test(expected = BigQueryConnectException.class, timeout = 60000L)
+  public void testSimplePutException() throws InterruptedException {
+    final String topic = "test-topic";
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+    when(bigQuery.insertAll(any())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(true);
+    when(insertAllResponse.getInsertErrors()).thenReturn(Collections.singletonMap(
+       0L, Collections.singletonList(new BigQueryError("no such field", "us-central1", ""))));
+
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
+    while (true) {
+      Thread.sleep(100);
+      testTask.put(Collections.emptyList());
+    }
+  }
+
+
+  // Since any exception thrown during flush causes Kafka Connect to not commit the offsets for any
+  // records sent to the task since the last flush. The task should fail, and next flush should
+  // also throw an error.
+  @Test(expected = BigQueryConnectException.class)
+  public void testFlushException() {
     final String dataset = "scratch";
     final String topic = "test_topic";
 


### PR DESCRIPTION
This back ports https://github.com/confluentinc/kafka-connect-bigquery/pull/14 and https://github.com/confluentinc/kafka-connect-bigquery/pull/18 into the 1.6.x branch. 

Please see https://github.com/confluentinc/kafka-connect-bigquery/issues/55. 

Tests are passing however I have not been able to test this directly against BigQuery. 