### PR TITLE
GH-68: Continue to check for errors in flush even after stopped

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -143,6 +143,9 @@ public class BigQuerySinkTask extends SinkTask {
 
     // Return immediately here since the executor will already be shutdown
     if (stopped) {
+      // Still have to check for errors in order to prevent offsets being committed for records that
+      // we've failed to write
+      executor.maybeThrowEncounteredErrors();
       return;
     }
 


### PR DESCRIPTION
Addresses #68, by causing calls to `flush` to fail even if the task has already been stopped.