### PR TITLE
GH-75: Make IdentitySchemaRetriever the default schema retriever for BQ 2.0.0

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -28,6 +28,7 @@ import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
+import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.config.ConfigDef;
@@ -125,7 +126,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public static final String SCHEMA_RETRIEVER_CONFIG =         "schemaRetriever";
   private static final ConfigDef.Type SCHEMA_RETRIEVER_TYPE =  ConfigDef.Type.CLASS;
-  private static final Class<?> SCHEMA_RETRIEVER_DEFAULT =     null;
+  private static final Class<?> SCHEMA_RETRIEVER_DEFAULT = IdentitySchemaRetriever.class;
   private static final ConfigDef.Importance SCHEMA_RETRIEVER_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final String SCHEMA_RETRIEVER_DOC =

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -163,14 +163,4 @@ public class BigQuerySinkTaskConfigTest {
     assertTrue(testClusteringPartitionFieldName.isPresent());
     assertEquals(expectedClusteringPartitionFieldName, testClusteringPartitionFieldName.get());
   }
-
-  @Test(expected = ConfigException.class)
-  public void testSchemaUpdatesWithoutRetriever() {
-    Map<String, String> badConfigProperties = propertiesFactory.getProperties();
-    badConfigProperties.remove(BigQuerySinkTaskConfig.SCHEMA_RETRIEVER_CONFIG);
-    badConfigProperties.put(BigQuerySinkTaskConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, "true");
-    badConfigProperties.put(BigQuerySinkTaskConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, "true");
-
-    new BigQuerySinkTaskConfig(badConfigProperties);
-  }
 }


### PR DESCRIPTION
## Problem 
Schema Retriever has no default currently and customers are confused on why that is the case/ whether Identity Schema Retriever should cover their use cases. The Identity Schema Retriever should cover most use cases and hence should be made the default.

## Related Issues

 https://github.com/confluentinc/kafka-connect-bigquery/issues/75 

## Solution

Make Identity Schema Retriever the default. 


## Release plan
Cut release 2.0.0 with this change


