### PR TITLE
MINOR: Catch 'too many rows present in the request' errors from BigQuery and reduce batch size in response

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -53,6 +53,7 @@ public class TableWriter implements Runnable {
   private static final int BAD_REQUEST_CODE = 400;
   private static final String INVALID_REASON = "invalid";
   private static final String PAYLOAD_TOO_LARGE_REASON = "Request payload size exceeds the limit:";
+  private static final String TOO_MANY_ROWS_REASON = "too many rows present in the request";
 
   private final BigQueryWriter writer;
   private final PartitionedTableId table;
@@ -159,7 +160,8 @@ public class TableWriter implements Runnable {
       return true;
     } else if (exception.getCode() == BAD_REQUEST_CODE
         && exception.getMessage() != null
-        && exception.getMessage().contains(PAYLOAD_TOO_LARGE_REASON)) {
+        && (exception.getMessage().contains(PAYLOAD_TOO_LARGE_REASON)
+        || exception.getMessage().contains(TOO_MANY_ROWS_REASON))) {
       return true;
     }
     return false;


### PR DESCRIPTION

Started seeing this error in the logs,

February 4th 2021, 14:10:59.979 | "message" : "too many rows present in the request, limit: 10000 row count: 10416.",

and causes connector tasks to keep failing