### PR TITLE
Add partition expiration

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -312,6 +312,7 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
     Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
     Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
+    Optional<Long> partitionExpiration = config.getPartitionExpirationMs();
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldName();
     boolean allowNewBQFields = config.getBoolean(config.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
     boolean allowReqFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
@@ -319,7 +320,7 @@ public class BigQuerySinkTask extends SinkTask {
     return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
                              allowNewBQFields, allowReqFieldRelaxation, allowSchemaUnionization,
                              kafkaKeyFieldName, kafkaDataFieldName,
-                             timestampPartitionFieldName, clusteringFieldName);
+                             timestampPartitionFieldName, partitionExpiration, clusteringFieldName);
   }
 
   private BigQueryWriter getBigQueryWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -119,7 +119,8 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_PARTITION_EXPIRATION_DOC =
           "The amount of time, in milliseconds, after which partitions should be deleted from the table. If this " +
                   "field is set, all data in partitions in this table older than the specified partition " +
-                  "expiration time will be permanently deleted.";
+                  "expiration time will be permanently deleted. " +
+                  "Existing tables will not be altered to use this partition expiration.";
 
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   private static final ConfigDef.Type BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE = ConfigDef.Type.LIST;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -117,10 +117,10 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_PARTITION_EXPIRATION_DEFAULT = null;
   private static final ConfigDef.Importance BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String BIGQUERY_PARTITION_EXPIRATION_DOC =
-          "The amount of time, in milliseconds, after which partitions should be deleted from the tables this " +
-          "connector creates. If this field is set, all data in partitions in this connector's tables that are " +
-          "older than the specified partition expiration time will be permanently deleted. " +
-          "Existing tables will not be altered to use this partition expiration time.";
+      "The amount of time, in milliseconds, after which partitions should be deleted from the tables this "
+      + "connector creates. If this field is set, all data in partitions in this connector's tables that are "
+      + "older than the specified partition expiration time will be permanently deleted. "
+      + "Existing tables will not be altered to use this partition expiration time.";
 
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   private static final ConfigDef.Type BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE = ConfigDef.Type.LIST;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -117,10 +117,10 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_PARTITION_EXPIRATION_DEFAULT = null;
   private static final ConfigDef.Importance BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String BIGQUERY_PARTITION_EXPIRATION_DOC =
-          "The amount of time, in milliseconds, after which partitions should be deleted from the table. If this " +
-                  "field is set, all data in partitions in this table older than the specified partition " +
-                  "expiration time will be permanently deleted. " +
-                  "Existing tables will not be altered to use this partition expiration.";
+          "The amount of time, in milliseconds, after which partitions should be deleted from the tables this " +
+          "connector creates. If this field is set, all data in partitions in this connector's tables that are " +
+          "older than the specified partition expiration time will be permanently deleted. " +
+          "Existing tables will not be altered to use this partition expiration time.";
 
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   private static final ConfigDef.Type BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE = ConfigDef.Type.LIST;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -112,6 +112,15 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
           + " and enable timestamp partitioning for each table. Leave this configuration blank,"
           + " to enable ingestion time partitioning for each table.";
 
+  public static final String BIGQUERY_PARTITION_EXPIRATION_CONFIG = "partitionExpirationMs";
+  private static final ConfigDef.Type BIGQUERY_PARTITION_EXPIRATION_TYPE = ConfigDef.Type.LONG;
+  private static final String BIGQUERY_PARTITION_EXPIRATION_DEFAULT = null;
+  private static final ConfigDef.Importance BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String BIGQUERY_PARTITION_EXPIRATION_DOC =
+          "The amount of time, in milliseconds, after which partitions should be deleted from the table. If this " +
+                  "field is set, all data in partitions older than the specified partition expiration time will be " +
+                  "permanently deleted.";
+
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   private static final ConfigDef.Type BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE = ConfigDef.Type.LIST;
   private static final List<String> BIGQUERY_CLUSTERING_FIELD_NAMES_DEFAULT = null;
@@ -179,6 +188,12 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
             BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_IMPORTANCE,
             BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_DOC
         ).define(
+            BIGQUERY_PARTITION_EXPIRATION_CONFIG,
+            BIGQUERY_PARTITION_EXPIRATION_TYPE,
+            BIGQUERY_PARTITION_EXPIRATION_DEFAULT,
+            BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE,
+            BIGQUERY_PARTITION_EXPIRATION_DOC
+        ).define(
             BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG,
             BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE,
             BIGQUERY_CLUSTERING_FIELD_NAMES_DEFAULT,
@@ -219,6 +234,14 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   }
 
   /**
+   * Returns the partition expiration in ms.
+   * @return Long that represents the partition expiration.
+   */
+  public Optional<Long> getPartitionExpirationMs() {
+    return Optional.ofNullable(getLong(BIGQUERY_PARTITION_EXPIRATION_CONFIG));
+  }
+
+  /**
    * Returns the field names to use for clustering.
    * @return List of Strings that represent the field names.
    */
@@ -236,6 +259,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
               + "Use either bigQueryPartitionDecorator OR timestampPartitionFieldName."
       );
     }
+    getPartitionExpirationMs().ifPresent(partitionExpiration -> {
+      if (partitionExpiration <= 0) {
+        throw new ConfigException("The partition expiration value must be positive.");
+      }
+    });
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -109,8 +109,8 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
       ConfigDef.Importance.LOW;
   private static final String BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_DOC =
       "The name of the field in the value that contains the timestamp to partition by in BigQuery"
-          + " and enable timestamp partitioning for each table. Leave this configuration blank,"
-          + " to enable ingestion time partitioning for each table.";
+      + " and enable timestamp partitioning for each table. Leave this configuration blank,"
+      + " to enable ingestion time partitioning for each table.";
 
   public static final String BIGQUERY_PARTITION_EXPIRATION_CONFIG = "partitionExpirationMs";
   private static final ConfigDef.Type BIGQUERY_PARTITION_EXPIRATION_TYPE = ConfigDef.Type.LONG;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -118,8 +118,8 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final ConfigDef.Importance BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String BIGQUERY_PARTITION_EXPIRATION_DOC =
           "The amount of time, in milliseconds, after which partitions should be deleted from the table. If this " +
-                  "field is set, all data in partitions older than the specified partition expiration time will be " +
-                  "permanently deleted.";
+                  "field is set, all data in partitions in this table older than the specified partition " +
+                  "expiration time will be permanently deleted.";
 
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   private static final ConfigDef.Type BIGQUERY_CLUSTERING_FIELD_NAMES_TYPE = ConfigDef.Type.LIST;
@@ -261,7 +261,8 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
     }
     getPartitionExpirationMs().ifPresent(partitionExpiration -> {
       if (partitionExpiration <= 0) {
-        throw new ConfigException("The partition expiration value must be positive.");
+        throw new ConfigException(BIGQUERY_PARTITION_EXPIRATION_CONFIG, partitionExpiration,
+                "The partition expiration value must be positive.");
       }
     });
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -181,11 +181,12 @@ public class SchemaManagerTest {
 
     Assert.assertEquals("Kafka doc does not match BigQuery table description",
         testDoc, tableInfo.getDescription());
+    StandardTableDefinition tableDefinition = (StandardTableDefinition) tableInfo.getDefinition();
     Assert.assertEquals("The partition expiration does not match the expiration in ms",
         testExpirationMs.get(),
-        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getExpirationMs());
+        tableDefinition.getTimePartitioning().getExpirationMs());
     Assert.assertNull("Timestamp partition field name is not null",
-        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getField());
+        tableDefinition.getTimePartitioning().getField());
   }
 
   @Test
@@ -203,12 +204,13 @@ public class SchemaManagerTest {
 
     Assert.assertEquals("Kafka doc does not match BigQuery table description",
         testDoc, tableInfo.getDescription());
+    StandardTableDefinition tableDefinition = (StandardTableDefinition) tableInfo.getDefinition();
     Assert.assertEquals("The partition expiration does not match the expiration in ms",
         testExpirationMs.get(),
-        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getExpirationMs());
+        tableDefinition.getTimePartitioning().getExpirationMs());
     Assert.assertEquals("The field name does not match the field name of time partition",
         testField.get(),
-        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getField());
+        tableDefinition.getTimePartitioning().getField());
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -103,6 +103,38 @@ public class BigQuerySinkTaskConfigTest {
   }
 
   /**
+   * Test the default for the partition expiration is not present.
+   */
+  @Test
+  public void testEmptyPartitionExpirationMs() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    BigQuerySinkTaskConfig testConfig = new BigQuerySinkTaskConfig(configProperties);
+    assertFalse(testConfig.getPartitionExpirationMs().isPresent());
+  }
+
+  /**
+   * Test the partition expiration is set correctly for a valid value.
+   */
+  @Test
+  public void testValidPartitionExpirationMs() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkTaskConfig.BIGQUERY_PARTITION_EXPIRATION_CONFIG, "1");
+    BigQuerySinkTaskConfig testConfig = new BigQuerySinkTaskConfig(configProperties);
+    assertTrue(testConfig.getPartitionExpirationMs().isPresent());
+    assertEquals(Optional.of(1L), testConfig.getPartitionExpirationMs());
+  }
+
+  /**
+   * Test the partition expiration being non-positive errors correctly.
+   */
+  @Test (expected = ConfigException.class)
+  public void testMinimumPartitionExpirationMs() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkTaskConfig.BIGQUERY_PARTITION_EXPIRATION_CONFIG, "0");
+    new BigQuerySinkTaskConfig(configProperties);
+  }
+
+  /**
    * Test the default for the field names is not present.
    */
   @Test


### PR DESCRIPTION
Co-authored by: Philippa Main <philippa.main@autotrader.co.uk>
on-behalf-of: @autotraderuk <dataengsupport@autotrader.co.uk>

Add partition expiration to a table. Partition expiration removes
partitions from the table after a specified amount of time.
It is an optional field in the connector.