### PR TITLE
GH-80: Add support for configuring time partitioning type on created tables

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -366,13 +366,14 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
     Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldName();
+    TimePartitioning.Type timePartitioningType = config.getTimePartitioningType();
     boolean allowNewBQFields = config.getBoolean(config.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
     boolean allowReqFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
     boolean allowSchemaUnionization = config.getBoolean(config.ALLOW_SCHEMA_UNIONIZATION_CONFIG);
     return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
                              allowNewBQFields, allowReqFieldRelaxation, allowSchemaUnionization,
                              kafkaKeyFieldName, kafkaDataFieldName,
-                             timestampPartitionFieldName, clusteringFieldName);
+                             timestampPartitionFieldName, clusteringFieldName, timePartitioningType);
   }
 
   private BigQueryWriter getBigQueryWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -67,6 +67,7 @@ public class SchemaManager {
   private final Optional<String> kafkaDataFieldName;
   private final Optional<String> timestampPartitionFieldName;
   private final Optional<List<String>> clusteringFieldName;
+  private final TimePartitioning.Type timePartitioningType;
   private final boolean intermediateTables;
   private final ConcurrentMap<TableId, Object> tableCreateLocks;
   private final ConcurrentMap<TableId, Object> tableUpdateLocks;
@@ -100,7 +101,8 @@ public class SchemaManager {
       Optional<String> kafkaKeyFieldName,
       Optional<String> kafkaDataFieldName,
       Optional<String> timestampPartitionFieldName,
-      Optional<List<String>> clusteringFieldName) {
+      Optional<List<String>> clusteringFieldName,
+      TimePartitioning.Type timePartitioningType) {
     this(
         schemaRetriever,
         schemaConverter,
@@ -112,6 +114,7 @@ public class SchemaManager {
         kafkaDataFieldName,
         timestampPartitionFieldName,
         clusteringFieldName,
+        timePartitioningType,
         false,
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
@@ -129,6 +132,7 @@ public class SchemaManager {
       Optional<String> kafkaDataFieldName,
       Optional<String> timestampPartitionFieldName,
       Optional<List<String>> clusteringFieldName,
+      TimePartitioning.Type timePartitioningType,
       boolean intermediateTables,
       ConcurrentMap<TableId, Object> tableCreateLocks,
       ConcurrentMap<TableId, Object> tableUpdateLocks,
@@ -143,6 +147,7 @@ public class SchemaManager {
     this.kafkaDataFieldName = kafkaDataFieldName;
     this.timestampPartitionFieldName = timestampPartitionFieldName;
     this.clusteringFieldName = clusteringFieldName;
+    this.timePartitioningType = timePartitioningType;
     this.intermediateTables = intermediateTables;
     this.tableCreateLocks = tableCreateLocks;
     this.tableUpdateLocks = tableUpdateLocks;
@@ -161,6 +166,7 @@ public class SchemaManager {
         kafkaDataFieldName,
         timestampPartitionFieldName,
         clusteringFieldName,
+        timePartitioningType,
         true,
         tableCreateLocks,
         tableUpdateLocks,
@@ -450,7 +456,7 @@ public class SchemaManager {
       // pseudocolumn can be queried to filter out rows that are still in the streaming buffer
       builder.setTimePartitioning(TimePartitioning.of(Type.DAY));
     } else if (createSchema) {
-      TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
+      TimePartitioning timePartitioning = TimePartitioning.of(timePartitioningType);
       if (timestampPartitionFieldName.isPresent()) {
         timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName.get()).build();
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -90,6 +90,7 @@ public class SchemaManager {
    *                                    If set to null, ingestion time-based partitioning will be
    *                                    used instead.
    * @param clusteringFieldName
+   * @param timePartitioningType The time partitioning type (HOUR, DAY, etc.) to use for created tables.
    */
   public SchemaManager(
       SchemaRetriever schemaRetriever,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -504,7 +504,23 @@ public class BigQuerySinkConfig extends AbstractConfig {
             TIME_PARTITIONING_TYPE_DEFAULT,
             ConfigDef.CaseInsensitiveValidString.in(TIME_PARTITIONING_TYPES.toArray(new String[0])),
             TIME_PARTITIONING_TYPE_IMPORTANCE,
-            TIME_PARTITIONING_TYPE_DOC
+            TIME_PARTITIONING_TYPE_DOC,
+            "",
+            -1,
+            ConfigDef.Width.NONE,
+            TIME_PARTITIONING_TYPE_CONFIG,
+            new ConfigDef.Recommender() {
+              @Override
+              public List<Object> validValues(String s, Map<String, Object> map) {
+                // Construct a new list to transform from List<String> to List<Object>
+                return new ArrayList<>(TIME_PARTITIONING_TYPES);
+              }
+
+              @Override
+              public boolean visible(String s, Map<String, Object> map) {
+                return true;
+              }
+            }
         );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -21,6 +21,7 @@ package com.wepay.kafka.connect.bigquery.config;
 
 import com.google.cloud.bigquery.Schema;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
@@ -51,6 +52,8 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Base class for connector and task configs; contains properties shared between the two of them.
@@ -297,6 +300,17 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "How many records to write to an intermediate table before performing a merge flush, if " 
       + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing.";
 
+  public static final String TIME_PARTITIONING_TYPE_CONFIG = "timePartitioningType";
+  private static final ConfigDef.Type TIME_PARTITIONING_TYPE_TYPE = ConfigDef.Type.STRING;
+  public static final String TIME_PARTITIONING_TYPE_DEFAULT = TimePartitioning.Type.DAY.name().toUpperCase();
+  private static final ConfigDef.Importance TIME_PARTITIONING_TYPE_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final List<String> TIME_PARTITIONING_TYPES = Stream.of(TimePartitioning.Type.values())
+      .map(TimePartitioning.Type::name)
+      .collect(Collectors.toList());
+  private static final String TIME_PARTITIONING_TYPE_DOC =
+      "The time partitioning type to use when creating tables. "
+          + "Existing tables will not be altered to use this partitioning type."; 
+
   /**
    * Return a ConfigDef object used to define this config's fields.
    *
@@ -484,6 +498,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
             MERGE_RECORDS_THRESHOLD_VALIDATOR,
             MERGE_RECORDS_THRESHOLD_IMPORTANCE,
             MERGE_RECORDS_THRESHOLD_DOC
+        ).define(
+            TIME_PARTITIONING_TYPE_CONFIG,
+            TIME_PARTITIONING_TYPE_TYPE,
+            TIME_PARTITIONING_TYPE_DEFAULT,
+            ConfigDef.CaseInsensitiveValidString.in(TIME_PARTITIONING_TYPES.toArray(new String[0])),
+            TIME_PARTITIONING_TYPE_IMPORTANCE,
+            TIME_PARTITIONING_TYPE_DOC
         );
   }
 
@@ -663,6 +684,27 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public boolean isUpsertDeleteEnabled() {
     return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
+  }
+
+  public TimePartitioning.Type getTimePartitioningType() {
+    return parseTimePartitioningType(getString(TIME_PARTITIONING_TYPE_CONFIG));
+  }
+
+  private TimePartitioning.Type parseTimePartitioningType(String rawPartitioningType) {
+    if (rawPartitioningType == null) {
+      throw new ConfigException(TIME_PARTITIONING_TYPE_CONFIG,
+          rawPartitioningType,
+          "Must be one of " + String.join(", ", TIME_PARTITIONING_TYPES));
+    }
+
+    try {
+      return TimePartitioning.Type.valueOf(rawPartitioningType);
+    } catch (IllegalArgumentException e) {
+      throw new ConfigException(
+          TIME_PARTITIONING_TYPE_CONFIG,
+          rawPartitioningType,
+          "Must be one of " + String.join(", ", TIME_PARTITIONING_TYPES));
+    }
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -31,6 +31,7 @@ import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
@@ -79,7 +80,8 @@ public class SchemaManagerTest {
     Optional<String> kafkaKeyFieldName = Optional.of("kafkaKey");
     Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, kafkaKeyFieldName, kafkaDataFieldName, Optional.empty(), Optional.empty());
+        mockBigQuery, false, false, false, kafkaKeyFieldName, kafkaDataFieldName, Optional.empty(), Optional.empty(),
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -97,7 +99,8 @@ public class SchemaManagerTest {
   public void testTimestampPartitionSet() {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty());
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty(),
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -109,16 +112,37 @@ public class SchemaManagerTest {
         testDoc, tableInfo.getDescription());
     StandardTableDefinition definition = tableInfo.getDefinition();
     Assert.assertNotNull(definition.getTimePartitioning());
+    Assert.assertEquals(TimePartitioning.Type.DAY, definition.getTimePartitioning().getType());
     Assert.assertEquals("The field name does not match the field name of time partition",
         testField.get(),
         definition.getTimePartitioning().getField());
   }
 
   @Test
+  public void testAlternativeTimestampPartitionType() {
+    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        TimePartitioning.Type.HOUR);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
+    when(mockKafkaSchema.doc()).thenReturn(testDoc);
+
+    TableInfo tableInfo = schemaManager
+        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+
+    Assert.assertEquals("Kafka doc does not match BigQuery table description",
+        testDoc, tableInfo.getDescription());
+    StandardTableDefinition definition = tableInfo.getDefinition();
+    Assert.assertNotNull(definition.getTimePartitioning());
+    Assert.assertEquals(TimePartitioning.Type.HOUR, definition.getTimePartitioning().getType());
+  }
+
+  @Test
   public void testUpdateTimestampPartitionNull() {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty());
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty(),
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -136,7 +160,8 @@ public class SchemaManagerTest {
   public void testUpdateTimestampPartitionNotSet() {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty());
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), testField, Optional.empty(),
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -154,7 +179,8 @@ public class SchemaManagerTest {
 
     Optional<String> updateField = Optional.of("testUpdateField");
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), updateField, Optional.empty());
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), updateField, Optional.empty(),
+        TimePartitioning.Type.DAY);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -168,7 +194,8 @@ public class SchemaManagerTest {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField);
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField,
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -190,7 +217,8 @@ public class SchemaManagerTest {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField);
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField,
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -209,7 +237,8 @@ public class SchemaManagerTest {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField);
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, testField,
+        TimePartitioning.Type.DAY);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -227,7 +256,8 @@ public class SchemaManagerTest {
 
     Optional<List<String>> updateTestField = Optional.of(Arrays.asList("column3", "column4"));
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, updateTestField);
+        mockBigQuery, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName, updateTestField,
+        TimePartitioning.Type.DAY);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -424,7 +454,8 @@ public class SchemaManagerTest {
       boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization) {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization,
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        TimePartitioning.Type.DAY);
   }
 
   private void testGetAndValidateProposedSchema(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -19,8 +19,10 @@
 
 package com.wepay.kafka.connect.bigquery.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.bigquery.TimePartitioning;
 import com.wepay.kafka.connect.bigquery.SinkPropertiesFactory;
 
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
@@ -78,5 +80,23 @@ public class BigQuerySinkConfigTest {
     );
 
     new BigQuerySinkConfig(badConfigProperties);
+  }
+
+  @Test
+  public void testValidTimePartitioningTypes() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+
+    for (TimePartitioning.Type type : TimePartitioning.Type.values()) {
+      configProperties.put(BigQuerySinkConfig.TIME_PARTITIONING_TYPE_CONFIG, type.name());
+      assertEquals(type, new BigQuerySinkConfig(configProperties).getTimePartitioningType());
+    }
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidTimePartitioningType() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+
+    configProperties.put(BigQuerySinkConfig.TIME_PARTITIONING_TYPE_CONFIG, "fortnight");
+    new BigQuerySinkConfig(configProperties);
   }
 }


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/80

Adds a new configuration property, `timePartitioningType`, that controls which time partitioning type to use for automatically-created tables. Valid values are (case-insensitive) `HOUR`, `DAY`, `MONTH`, or `YEAR`, and if any additional time partitioning types are added to the Java BigQuery SDK, those should be picked up automatically as well.

Existing test coverage was pretty good for this, so I only modified one unit test and added three new ones.