### PR TITLE
Prevent NPE thrown at SchemaManager.isFieldRelaxation() by specifying unspecified field mode as NULLABLE

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
@@ -317,6 +318,27 @@ public class SchemaManagerTest {
     SchemaManager schemaManager = createSchemaManager(true, true, true);
 
     testGetAndValidateProposedSchema(schemaManager, existingSchema, newSchemas, expectedSchema);
+  }
+
+  @Test
+  public void FieldsWithUnspecifiedModeShouldNotCauseNpe() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).build()
+    );
+
+    com.google.cloud.bigquery.Schema expectedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, true, true);
+
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, expectedSchema);
   }
 
   private SchemaManager createSchemaManager(


### PR DESCRIPTION
We are using v2.0.0. Several instances encountered NPE at https://github.com/confluentinc/kafka-connect-bigquery/blob/52c5451683dacfcee054c7d6721f386bad9d05bb/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java#L389-L390 . So either `currentField.getMode()==null`, or `proposedField.getMode()==null`. According to google's doc https://cloud.google.com/bigquery/docs/schemas#modes , `mode==null`, or mode is unspecified, is equivalent to `mode==NULLABLE`. 

To mitigate the issue, and to help with further debugging, I made two changes on top of 2.0.x:
1.  While retrieving fields from BigQuery schema, the connector does an additional check to see if the mode is unspecified, or in other words, equals `null`, and if so, set it to its equivalence, NULLABLE;
2. Add a TRACE log message to print out existing schema and proposed schema.

The PR is targeting at 2.0.x. Once merged, we will pint merge all the way to master, and release a new version off 2.0.x.