### PR TITLE
MINOR: Increase retry period for writes after table creates/updates to 15 minutes

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -50,8 +50,8 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
   private static final Logger logger = LoggerFactory.getLogger(AdaptiveBigQueryWriter.class);
 
   // The maximum number of retries we will attempt to write rows after creating a table or updating a BQ table schema.
-  private static final int RETRY_LIMIT = 10;
-  // Wait for about 30s between each retry since both creating table and updating schema take up to 2~3 minutes to take effect.
+  private static final int RETRY_LIMIT = 30;
+  // Wait for about 30s between each retry to avoid hammering BigQuery with requests
   private static final int RETRY_WAIT_TIME = 30000;
 
   private final BigQuery bigQuery;


### PR DESCRIPTION
We've had some reports that the connector fails (especially when upsert/delete is enabled) after creating a new table because it keeps getting 404 errors. After bumping this value the errors stopped and the connector was able to work smoothly.