### PR TITLE
GH-96 (follow-up): Include REPEATED fields in unionized schemas if missing from later schemas

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -350,6 +350,8 @@ public class SchemaManager {
         // Repeated fields are implicitly nullable; no need to set a new mode for them
         if (!Field.Mode.REPEATED.equals(firstField.getMode())) {
           unionizedSchemaFields.put(name, firstField.toBuilder().setMode(Field.Mode.NULLABLE).build());
+        } else {
+          unionizedSchemaFields.put(name, firstField);
         }
       } else if (isFieldRelaxation(firstField, secondField)) {
         unionizedSchemaFields.put(name, secondField);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -133,7 +133,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
           writeResponse = bigQuery.insertAll(request);
         } catch (BigQueryException exception) {
           // no-op, we want to keep retrying the insert
-          logger.trace("insertion failed", exception);
+          logger.debug("insertion failed", exception);
         }
       } else {
         return writeResponse.getInsertErrors();

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -261,7 +261,7 @@ public class SchemaManagerTest {
 
   @Test
   public void testSuccessfulUnionizedUpdateWithNewRepeatedField() {
-    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+    com.google.cloud.bigquery.Schema reducedSchema = com.google.cloud.bigquery.Schema.of(
         Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
     );
 
@@ -277,7 +277,9 @@ public class SchemaManagerTest {
 
     SchemaManager schemaManager = createSchemaManager(true, true, true);
 
-    testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, expectedSchema);
+    // Unionization should work symmetrically, so test both cases of reduced/expanded as the current/new schemas
+    testGetAndValidateProposedSchema(schemaManager, reducedSchema, expandedSchema, expectedSchema);
+    testGetAndValidateProposedSchema(schemaManager, expandedSchema, reducedSchema, expectedSchema);
   }
 
   @Test
@@ -300,6 +302,7 @@ public class SchemaManagerTest {
 
     testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, expectedSchema);
   }
+
   @Test(expected = BigQueryConnectException.class)
   public void testDisallowedUnionizedUpdateWithNewField() {
     com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(


### PR DESCRIPTION
https://github.com/confluentinc/kafka-connect-bigquery/pull/99 attempted to fix schema unionization logic for `REPEATED` fields but missed an important case: when the `REPEATED` field was present in one of the schemas seen, but missing from a later schema (as opposed to being added at a certain point, and contained in all subsequent schemas).

This fix addresses that case and verifies behavior by expanding on an existing unit test.