### PR TITLE
Remove check that BigQuery table exists for batch load

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -117,12 +117,6 @@ public class GCSToBQWriter {
     BlobInfo blobInfo =
          BlobInfo.newBuilder(blobId).setContentType("text/json").setMetadata(metadata).build();
 
-    // Check if the table specified exists
-    // This error shouldn't be thrown. All tables should be created by the connector at startup
-    if (autoCreateTables && bigQuery.getTable(tableId) == null) {
-      attemptTableCreate(tableId, new ArrayList<>(rows.keySet()));
-    }
-
     int attemptCount = 0;
     boolean success = false;
     while (!success && (attemptCount <= retries)) {


### PR DESCRIPTION
This check is part of the batch loading process. The check is made when files are being staged to GCS. At a certain scale, you begin to exceed BigQuery rate limits for API calls, documented at https://cloud.google.com/bigquery/quotas#api_requests.

The check could be wrapped and re-tried with backoff, or moved out of the critical path, but as the comment says the tables should be created at connector startup, I figured the best thing is to remove it and focus on making sure table creation at startup works.