### PR TITLE
MINOR: Remove outdated properties

### DIFF
--- a/kcbq-connector/quickstart/properties/connector.properties
+++ b/kcbq-connector/quickstart/properties/connector.properties
@@ -30,10 +30,6 @@ autoUpdateSchemas=true
 schemaRetriever=com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever.SchemaRegistrySchemaRetriever
 schemaRegistryLocation=http://localhost:8081
 
-bufferSize=100000
-maxWriteSize=10000
-tableWriteWait=1000
-
 ########################################### Fill me in! ###########################################
 # The name of the BigQuery project to write to
 project=


### PR DESCRIPTION
These properties haven't been used by the connector for a long time; we should remove them from the code base in order to avoid confusing users.