### PR TITLE
GH-65: Add support for Kafka logical Time type

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 
 import java.math.BigDecimal;
@@ -37,6 +38,7 @@ public class KafkaLogicalConverters {
     LogicalConverterRegistry.register(Date.LOGICAL_NAME, new DateConverter());
     LogicalConverterRegistry.register(Decimal.LOGICAL_NAME, new DecimalConverter());
     LogicalConverterRegistry.register(Timestamp.LOGICAL_NAME, new TimestampConverter());
+    LogicalConverterRegistry.register(Time.LOGICAL_NAME, new TimeConverter());
   }
 
   /**
@@ -94,6 +96,26 @@ public class KafkaLogicalConverters {
     @Override
     public String convert(Object kafkaConnectObject) {
       return getBqTimestampFormat().format((java.util.Date) kafkaConnectObject);
+    }
+  }
+
+
+  /**
+   * Class for converting Kafka time logical types to BigQuery time types.
+   */
+  public static class TimeConverter extends LogicalTypeConverter {
+    /**
+     * Create a new TimestampConverter.
+     */
+    public TimeConverter() {
+      super(Time.LOGICAL_NAME,
+          Schema.Type.INT32,
+          LegacySQLTypeName.TIME);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      return getBqTimeFormat().format((java.util.Date) kafkaConnectObject);
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -88,10 +88,10 @@ public abstract class LogicalTypeConverter {
     return bqTimestampFormat;
   }
 
-  protected static SimpleDateFormat getBQDatetimeFormat() {
-    SimpleDateFormat bqDateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-    bqDateTimeFormat.setTimeZone(utcTimeZone);
-    return bqDateTimeFormat;
+  protected SimpleDateFormat getBqTimeFormat() {
+    SimpleDateFormat bqTimestampFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    bqTimestampFormat.setTimeZone(utcTimeZone);
+    return bqTimestampFormat;
   }
 
   protected static SimpleDateFormat getBQDateFormat() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DateConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DecimalConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimestampConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimeConverter;
 
 import org.apache.kafka.connect.data.Schema;
 
@@ -100,5 +101,33 @@ public class KafkaLogicalConvertersTest {
     String formattedTimestamp = converter.convert(date);
 
     assertEquals("2017-03-01 22:20:38.808", formattedTimestamp);
+  }
+
+
+  @Test
+  public void testTimeConversion() {
+    TimeConverter converter = new KafkaLogicalConverters.TimeConverter();
+
+    assertEquals(LegacySQLTypeName.TIME, converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+    } catch (Exception ex) {
+      fail("Expected encoding type check to succeed.");
+    }
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+      fail("Expected encoding type check to fail");
+    } catch (Exception ex) {
+      // continue
+    }
+
+    // Can't use the same timestamp here as the one in other tests as the Time type
+    // should only fall on January 1st, 1970
+    Date date = new Date(166838808);
+    String formattedTimestamp = converter.convert(date);
+
+    assertEquals("22:20:38.808", formattedTimestamp);
   }
 }


### PR DESCRIPTION
Addresses #65 by adding a logical converter for the connect `Time` type. This should be fully backwards-compatible (explained in detail on the issue).