### PR TITLE
Prevent NPE for tombstone records when delete is enabled

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -100,6 +100,9 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
    *         existing one.
    */
   public com.google.cloud.bigquery.Schema convertSchema(Schema kafkaConnectSchema) {
+    if (kafkaConnectSchema == null) {
+      return com.google.cloud.bigquery.Schema.of();
+    }
     // TODO: Permit non-struct keys
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -555,6 +555,13 @@ public class BigQuerySchemaConverterTest {
   }
 
   @Test
+  public void testTombstone() {
+    com.google.cloud.bigquery.Schema bigQueryTestSchema =
+        new BigQuerySchemaConverter(true).convertSchema(null);
+    assertEquals(com.google.cloud.bigquery.Schema.of(), bigQueryTestSchema);
+  }
+
+  @Test
   public void testNullable() {
     final String nullableFieldName = "Nullable";
     final String requiredFieldName = "Required";


### PR DESCRIPTION
The connector hits an NPE when it hits a tombstone record if delete is enabled.
The exact case is:
Connector has upsert and delete enabled,
Table has timestamp filed partition
Tombstone message has a key of integer.

Sample log. 
[timestamp] TRACE: Applying transformations to record in topic 'test_topic' partition 1 at offset 11111 and timestamp 1621599043906 with key Struct{KEY=1234567} and value null (org.apache.kafka.connect.runtime.WorkerSinkTask:518)

Return an empty schema in `BigQuerySchemaConverter#convertSchema` if keySchema is null.
