### PR TITLE
Prevent records with null value schema from causing NPE when delete is enabled

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -495,7 +495,13 @@ public class SchemaManager {
   }
 
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
+    // When converting schema from the last record of a batch, if the record is a tombstone with
+    // null value schema, only allow it to pass if schema unionization is enabled.
     if (kafkaValueSchema == null) {
+      if (!allowSchemaUnionization) {
+        throw new BigQueryConnectException(
+            "Cannot convert schema for record with value schema.");
+      }
       return com.google.cloud.bigquery.Schema.of();
     }
     com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -495,6 +495,9 @@ public class SchemaManager {
   }
 
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
+    if (kafkaValueSchema == null) {
+      return com.google.cloud.bigquery.Schema.of();
+    }
     com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
 
     List<Field> schemaFields = intermediateTables

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -500,7 +500,8 @@ public class SchemaManager {
     if (kafkaValueSchema == null) {
       if (!allowSchemaUnionization) {
         throw new BigQueryConnectException(
-            "Cannot convert schema for record with value schema.");
+            "Cannot create/update BigQuery table for record with no value schema. "
+            + "If delete mode is enabled, it may be necessary to enable schema unionization to handle this case.");
       }
       return com.google.cloud.bigquery.Schema.of();
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -100,6 +100,9 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
    *         existing one.
    */
   public com.google.cloud.bigquery.Schema convertSchema(Schema kafkaConnectSchema) {
+    if (kafkaConnectSchema == null) {
+      return com.google.cloud.bigquery.Schema.of();
+    }
     // TODO: Permit non-struct keys
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -100,9 +100,6 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
    *         existing one.
    */
   public com.google.cloud.bigquery.Schema convertSchema(Schema kafkaConnectSchema) {
-    if (kafkaConnectSchema == null) {
-      return com.google.cloud.bigquery.Schema.of();
-    }
     // TODO: Permit non-struct keys
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -395,7 +395,7 @@ public class SchemaManagerTest {
         Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
     );
 
-    SchemaManager schemaManager = createSchemaManager(false, true, true);
+    SchemaManager schemaManager = createSchemaManager(false, true, false);
     testGetAndValidateProposedSchema(schemaManager, existingSchema, ImmutableList.of(newSchema),
         com.google.cloud.bigquery.Schema.of(), recordWithNullValueSchema());
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -19,7 +19,6 @@
 
 package com.wepay.kafka.connect.bigquery;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +34,6 @@ import com.google.cloud.bigquery.TableInfo;
 
 import com.google.common.collect.ImmutableList;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
-import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -443,23 +443,10 @@ public class SchemaManagerTest {
       com.google.cloud.bigquery.Schema existingSchema,
       List<com.google.cloud.bigquery.Schema> newSchemas,
       com.google.cloud.bigquery.Schema expectedSchema) {
-    testGetAndValidateProposedSchema(
-        schemaManager,
-        existingSchema,
-        newSchemas,
-        expectedSchema,
-        recordWithValueSchema(mockKafkaSchema));
-  }
-
-  private void testGetAndValidateProposedSchema(
-      SchemaManager schemaManager,
-      com.google.cloud.bigquery.Schema existingSchema,
-      List<com.google.cloud.bigquery.Schema> newSchemas,
-      com.google.cloud.bigquery.Schema expectedSchema,
-      SinkRecord sinkRecord) {
     Table existingTable = existingSchema != null ? tableWithSchema(existingSchema) : null;
 
-    List<SinkRecord> incomingSinkRecords = Collections.nCopies(newSchemas.size(), sinkRecord);
+    SinkRecord mockSinkRecord = recordWithValueSchema(mockKafkaSchema);
+    List<SinkRecord> incomingSinkRecords = Collections.nCopies(newSchemas.size(), mockSinkRecord);
 
     when(mockBigQuery.getTable(tableId)).thenReturn(existingTable);
     OngoingStubbing<com.google.cloud.bigquery.Schema> converterStub =

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 
-import com.google.common.collect.ImmutableList;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -552,13 +551,6 @@ public class BigQuerySchemaConverterTest {
         .build();
 
     new BigQuerySchemaConverter(false).convertSchema(kafkaConnectTestSchema);
-  }
-
-  @Test
-  public void testTombstone() {
-    com.google.cloud.bigquery.Schema bigQueryTestSchema =
-        new BigQuerySchemaConverter(true).convertSchema(null);
-    assertEquals(com.google.cloud.bigquery.Schema.of(), bigQueryTestSchema);
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -555,6 +555,13 @@ public class BigQuerySchemaConverterTest {
   }
 
   @Test
+  public void testTombstone() {
+    com.google.cloud.bigquery.Schema bigQueryTestSchema =
+        new BigQuerySchemaConverter(true).convertSchema(null);
+    assertEquals(com.google.cloud.bigquery.Schema.of(), bigQueryTestSchema);
+  }
+
+  @Test
   public void testNullable() {
     final String nullableFieldName = "Nullable";
     final String requiredFieldName = "Required";


### PR DESCRIPTION
The connector throws an NPE when it hits a tombstone with null value schema record if delete is enabled.
Reproduced with the following conditions:
Connector has upsert and delete enabled,
Table has timestamp filed partition,
Tombstone message has null value.

Sample log.
[timestamp] TRACE: Applying transformations to record in topic 'test_topic' partition 1 at offset 11111 and timestamp 1621599043906 with key Struct{KEY=1234567} and value null (org.apache.kafka.connect.runtime.WorkerSinkTask:518)
Stack trace on v2.1.3
```
java.lang.NullPointerException
	at com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter.convertSchema(BigQuerySchemaConverter.java:104)
	at com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter.convertSchema(BigQuerySchemaConverter.java:46)
	at com.wepay.kafka.connect.bigquery.SchemaManager.getBigQuerySchema(SchemaManager.java:507)
	at com.wepay.kafka.connect.bigquery.SchemaManager.convertRecordSchema(SchemaManager.java:323)
	at com.wepay.kafka.connect.bigquery.SchemaManager.getAndValidateProposedSchema(SchemaManager.java:294)
	at com.wepay.kafka.connect.bigquery.SchemaManager.getTableInfo(SchemaManager.java:277)
	at com.wepay.kafka.connect.bigquery.SchemaManager.createTable(SchemaManager.java:223)
```