### PR TITLE
Include key schema in proposed schema in the cases where value is null.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -431,7 +431,8 @@ public class SchemaManager {
    * @param records The records used to get the unionized table description
    * @return The resulting table description
    */
-  private String getUnionizedTableDescription(List<SinkRecord> records) {
+  @VisibleForTesting
+  String getUnionizedTableDescription(List<SinkRecord> records) {
     String tableDescription = null;
     for (SinkRecord record : records) {
       Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -435,6 +435,9 @@ public class SchemaManager {
     String tableDescription = null;
     for (SinkRecord record : records) {
       Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
+      if (kafkaValueSchema == null) {
+        continue;
+      }
       tableDescription = kafkaValueSchema.doc() != null ? kafkaValueSchema.doc() : tableDescription;
     }
     return tableDescription;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -503,9 +503,12 @@ public class SchemaManager {
             "Cannot create/update BigQuery table for record with no value schema. "
             + "If delete mode is enabled, it may be necessary to enable schema unionization to handle this case.");
       }
-      return com.google.cloud.bigquery.Schema.of();
     }
-    com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
+
+    com.google.cloud.bigquery.Schema valueSchema = com.google.cloud.bigquery.Schema.of();;
+    if (kafkaValueSchema != null) {
+      valueSchema  = schemaConverter.convertSchema(kafkaValueSchema);
+    }
 
     List<Field> schemaFields = intermediateTables
         ? getIntermediateSchemaFields(valueSchema, kafkaKeySchema)

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -422,6 +422,14 @@ public class SchemaManagerTest {
     Assert.assertEquals(expectedSchema, proposedSchema);
   }
 
+  @Test
+  public void testGetUnionizedTableDescriptionFromNullValueSchema() {
+    SchemaManager schemaManager = createSchemaManager(false, true, true);
+    SinkRecord tombstone = recordWithValueSchema(null);
+    List<SinkRecord> incomingSinkRecords = ImmutableList.of(tombstone);
+    Assert.assertNull(schemaManager.getUnionizedTableDescription(incomingSinkRecords));
+  }
+
   private SchemaManager createSchemaManager(
       boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization) {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,


### PR DESCRIPTION
The previous attempt [PR117](https://github.com/confluentinc/kafka-connect-bigquery/pull/117) to fix an NPE thrown when record value is null (tombstone) had 2 problems:
1. It skipped key schema of the record when proposing a new BigQuery schema, which would result an intermediate table with no schema at all. Task would fail in this case, and delete wouldn't work.
2. After validating proposed schema, the connector would generate description for the new table from value schema. Here the other NPE is thrown because value schema is null.

To fix the above 2 issues, this PR does:
1. Include the fields of record key schema in the new BigQuery table schema, so that delete works properly.
2. Skip null value schema to avoid NPE when getting description for the new table.