### PR TITLE
Retry on IOException

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -97,7 +97,7 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
-          logger.warn("Could not write batch of size {} to BigQuery.", currentBatchList.size(), err);
+          logger.warn("Could not write batch of size {} to BigQuery. (Error code {})", currentBatchList.size(), err.getCode(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);


### PR DESCRIPTION
From time to time we would have tasks fail due to a com.google.cloud.bigquery.BigQueryException: Connection reset

Is seems that the connection reset comes from the BigQuery end. 

This PR adds IOException handling to the existing retry logic.

We have been running this stable for the past 2 months.