### PR TITLE
Skip record with null valueSchema when proposing new BigQuery schema.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -283,7 +283,16 @@ public class SchemaManager {
       result = getUnionizedSchema(bigQuerySchemas);
     } else {
       com.google.cloud.bigquery.Schema existingSchema = readTableSchema(table);
-      result = convertRecordSchema(records.get(records.size() - 1));
+      SinkRecord recordToConvert = getRecordToConvert(records);
+      if (recordToConvert == null) {
+        String errorMessage = "Could not convert to BigQuery schema with a batch of tombstone records.";
+        if (existingSchema == null) {
+          throw new BigQueryConnectException(errorMessage);
+        }
+        logger.debug(errorMessage + " Will reuse existing schema.");
+        return existingSchema;
+      }
+      result = convertRecordSchema(recordToConvert);
       if (existingSchema != null) {
         validateSchemaChange(existingSchema, result);
         if (allowBQRequiredFieldRelaxation) {
@@ -304,9 +313,30 @@ public class SchemaManager {
     List<com.google.cloud.bigquery.Schema> bigQuerySchemas = new ArrayList<>();
     Optional.ofNullable(readTableSchema(table)).ifPresent(bigQuerySchemas::add);
     for (SinkRecord record : records) {
+      Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
+      if (kafkaValueSchema == null) {
+        continue;
+      }
       bigQuerySchemas.add(convertRecordSchema(record));
     }
     return bigQuerySchemas;
+  }
+
+  /**
+   * Gets a regular record from the given batch of SinkRecord for schema conversion. This is needed
+   * when delete is enabled, because a tombstone record has null value, thus null value schema.
+   * Converting null value schema to BigQuery schema is not possible.
+   * @param records List of SinkRecord to look for.
+   * @return a regular record or null if the whole batch are all tombstone records.
+   */
+  private SinkRecord getRecordToConvert(List<SinkRecord> records) {
+    for (int i = records.size() - 1; i >= 0; i--) {
+      SinkRecord record = records.get(i);
+      if (schemaRetriever.retrieveValueSchema(record) != null) {
+        return record;
+      }
+    }
+    return null;
   }
 
   private com.google.cloud.bigquery.Schema convertRecordSchema(SinkRecord record) {
@@ -495,16 +525,6 @@ public class SchemaManager {
   }
 
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
-    // When converting schema from the last record of a batch, if the record is a tombstone with
-    // null value schema, only allow it to pass if schema unionization is enabled.
-    if (kafkaValueSchema == null) {
-      if (!allowSchemaUnionization) {
-        throw new BigQueryConnectException(
-            "Cannot create/update BigQuery table for record with no value schema. "
-            + "If delete mode is enabled, it may be necessary to enable schema unionization to handle this case.");
-      }
-      return com.google.cloud.bigquery.Schema.of();
-    }
     com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
 
     List<Field> schemaFields = intermediateTables

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -289,7 +289,7 @@ public class SchemaManager {
         if (existingSchema == null) {
           throw new BigQueryConnectException(errorMessage);
         }
-        logger.debug(errorMessage + " Will reuse existing schema.");
+        logger.debug(errorMessage + " Will fall back to existing schema.");
         return existingSchema;
       }
       result = convertRecordSchema(recordToConvert);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -461,10 +461,14 @@ public class SchemaManager {
    * @param records The records used to get the unionized table description
    * @return The resulting table description
    */
-  private String getUnionizedTableDescription(List<SinkRecord> records) {
+  @VisibleForTesting
+  String getUnionizedTableDescription(List<SinkRecord> records) {
     String tableDescription = null;
     for (SinkRecord record : records) {
       Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
+      if (kafkaValueSchema == null) {
+        continue;
+      }
       tableDescription = kafkaValueSchema.doc() != null ? kafkaValueSchema.doc() : tableDescription;
     }
     return tableDescription;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -38,8 +38,11 @@ import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
+import java.util.Random;
 import org.apache.kafka.connect.data.Schema;
 
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Assert;
 import org.junit.Before;
@@ -386,11 +389,61 @@ public class SchemaManagerTest {
   }
 
   @Test
-  public void testGetUnionizedTableDescriptionFromNullValueSchema() {
+  public void testUpdateWithOnlyTombstoneRecordsAndExistingSchema() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+    List<SinkRecord> incomingSinkRecords = Collections.nCopies(2, recordWithValueSchema(null));
+    // Tombstone records are skipped, and existing schema is reused.
+    testGetAndValidateProposedSchema(schemaManager, existingSchema,
+        Collections.singletonList(existingSchema), existingSchema, incomingSinkRecords);
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testUpdateWithOnlyTombstoneRecordsNoExistingSchema() {
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+    List<SinkRecord> incomingSinkRecords = Collections.nCopies(2, recordWithValueSchema(null));
+    testGetAndValidateProposedSchema(
+        schemaManager, null, Collections.singletonList(null), null, incomingSinkRecords);
+  }
+
+  @Test
+  public void testUpdateWithRegularAndTombstoneRecords() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build()
+    );
+
+    com.google.cloud.bigquery.Schema expandedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build()
+    );
+
+    SchemaManager schemaManager = createSchemaManager(true, false, false);
+    // Put tombstone at the end of the batch.
+    List<SinkRecord> incomingSinkRecords = ImmutableList.of(
+        recordWithValueSchema(mockKafkaSchema), recordWithValueSchema(null));
+    // Tombstone record is skipped when converting schema.
+    testGetAndValidateProposedSchema(schemaManager, existingSchema,
+        Collections.singletonList(expandedSchema), expandedSchema, incomingSinkRecords);
+  }
+
+  @Test
+  public void testGetUnionizedTableDescriptionFromTombstoneRecord() {
     SchemaManager schemaManager = createSchemaManager(false, true, true);
     SinkRecord tombstone = recordWithValueSchema(null);
     List<SinkRecord> incomingSinkRecords = ImmutableList.of(tombstone);
     Assert.assertNull(schemaManager.getUnionizedTableDescription(incomingSinkRecords));
+  }
+
+  @Test
+  public void testGetUnionizedTableDescriptionFromRegularAndNullRecords() {
+    SchemaManager schemaManager = createSchemaManager(false, true, true).forIntermediateTables();
+    List<SinkRecord> incomingSinkRecords = ImmutableList.of(
+        recordWithValueSchema(mockKafkaSchema), recordWithValueSchema(null));
+    when(mockKafkaSchema.doc()).thenReturn(testDoc);
+    Assert.assertNotNull(schemaManager.getUnionizedTableDescription(incomingSinkRecords));
   }
 
   private SchemaManager createSchemaManager(
@@ -414,11 +467,17 @@ public class SchemaManagerTest {
       com.google.cloud.bigquery.Schema existingSchema,
       List<com.google.cloud.bigquery.Schema> newSchemas,
       com.google.cloud.bigquery.Schema expectedSchema) {
+    testGetAndValidateProposedSchema(schemaManager, existingSchema, newSchemas, expectedSchema,
+        Collections.nCopies(newSchemas.size(), recordWithValueSchema(mockKafkaSchema)));
+  }
+
+  private void testGetAndValidateProposedSchema(
+      SchemaManager schemaManager,
+      com.google.cloud.bigquery.Schema existingSchema,
+      List<com.google.cloud.bigquery.Schema> newSchemas,
+      com.google.cloud.bigquery.Schema expectedSchema,
+      List<SinkRecord> incomingSinkRecords) {
     Table existingTable = existingSchema != null ? tableWithSchema(existingSchema) : null;
-
-    SinkRecord mockSinkRecord = recordWithValueSchema(mockKafkaSchema);
-    List<SinkRecord> incomingSinkRecords = Collections.nCopies(newSchemas.size(), mockSinkRecord);
-
     when(mockBigQuery.getTable(tableId)).thenReturn(existingTable);
     OngoingStubbing<com.google.cloud.bigquery.Schema> converterStub =
         when(mockSchemaConverter.convertSchema(mockKafkaSchema));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -385,6 +385,14 @@ public class SchemaManagerTest {
     testGetAndValidateProposedSchema(schemaManager, existingSchema, expandedSchema, expectedSchema);
   }
 
+  @Test
+  public void testGetUnionizedTableDescriptionFromNullValueSchema() {
+    SchemaManager schemaManager = createSchemaManager(false, true, true);
+    SinkRecord tombstone = recordWithValueSchema(null);
+    List<SinkRecord> incomingSinkRecords = ImmutableList.of(tombstone);
+    Assert.assertNull(schemaManager.getUnionizedTableDescription(incomingSinkRecords));
+  }
+
   private SchemaManager createSchemaManager(
       boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization) {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,


### PR DESCRIPTION
The previous attempt [PR117](https://github.com/confluentinc/kafka-connect-bigquery/pull/117) to fix an NPE thrown when record value is null (tombstone) had 2 problems:
1. If unionization is not turned on, it would disallow tombstone records when proposing a new BigQuery schema. Delete wouldn't not be supported.
2. Another NPE which was covered by previous NPE was exposed, because tombstone records were passed to `getUnionizedTableDescription`

To fix the above 2 issues, this PR does:
1. Revert the behavior of not allowing tombstone records when unionization is turned off.
2. Change the behavior of only checking the last record from the batch when proposing new schema when unionization is turned off. Instead, `SchemaManager` would look for a regular record with non-null value schema. In the case where the batch only contains tombstone records, fall back to existing schema if possible. Otherwise, throw an exception. 
3. Skip null value schema to avoid NPE when getting description for the new table when unionization is turned on.