### PR TITLE
Adding message metadata in logs in case of errors

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -173,6 +173,7 @@ public abstract class BigQueryWriter {
     for (Map.Entry<SinkRecord, InsertAllRequest.RowToInsert> row: rows.entrySet()) {
       if (failRowsSet.contains((long)index)) {
         failRows.put(row.getKey(), row.getValue());
+        logger.trace("Failed Record: {}", row);
       }
       index++;
     }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -673,7 +673,8 @@ public class BigQuerySchemaConverterTest {
     Schema connectSchema = new AvroData(100).toConnectSchema(recursiveAvroSchema);
     ConversionConnectException e = assertThrows(ConversionConnectException.class, () ->
         new BigQuerySchemaConverter(true).convertSchema(connectSchema));
-    assertEquals("Kafka Connect schema contains cycle", e.getMessage());
+      assertEquals(String.format("Kafka Connect schema %s contains cycle. The attribute %s is defined recursively.",
+              recursiveAvroSchema.getFullName(), fieldName), e.getMessage());
   }
 
   @Test
@@ -694,6 +695,7 @@ public class BigQuerySchemaConverterTest {
     Schema connectSchema = new AvroData(100).toConnectSchema(recursiveAvroSchema);
     ConversionConnectException e = assertThrows(ConversionConnectException.class, () ->
         new BigQuerySchemaConverter(true).convertSchema(connectSchema));
-    assertEquals("Kafka Connect schema contains cycle", e.getMessage());
+    assertEquals(String.format("Kafka Connect schema %s contains cycle. The attribute %s is defined recursively.",
+            recursiveAvroSchema.getFullName(), fieldName), e.getMessage());
   }
 }


### PR DESCRIPTION
Hello,

We have difficult to identify bad messages in ours workloads. We need to know the topic/partition/offset of problematic message.
In the PR we propose to include topic/partition/offset/timestamp information in the log In case of error in BigQuery side and also a log for schema `cycle error`.

Thank you