### PR TITLE
Use https://packages.confluent.io/ instaed of http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <repository>
             <id>jcenter</id>
@@ -113,7 +113,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </pluginRepository>
         <pluginRepository>
             <id>jcenter</id>


### PR DESCRIPTION
As mentioned in https://github.com/confluentinc/kafka-connect-bigquery/issues/98, `mvn clean package -DskipTests` fails with maven 3.8.1 because the external HTTP repository is blocked by default. https://maven.apache.org/docs/3.8.1/release-notes.html
Why don't you use `https` instead?