### PR TITLE
GH-144: Isolate error classification logic into single, testable class

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 
 /**
@@ -76,18 +75,6 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     this.autoCreateTables = autoCreateTables;
   }
 
-  private boolean isTableMissingSchema(BigQueryException exception) {
-    // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
-    // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors
-    return exception.getReason() != null && exception.getReason().equalsIgnoreCase("invalid");
-  }
-
-  private boolean isTableNotExistedException(BigQueryException exception) {
-    // If a table does not exist, it will raise a BigQueryException that the input is notFound
-    // Referring to Google Cloud Error Codes Doc: https://cloud.google.com/bigquery/docs/error-messages?hl=en
-    return exception.getCode() == 404;
-  }
-
   /**
    * Sends the request to BigQuery, then checks the response to see if any errors have occurred. If
    * any have, and all errors can be blamed upon invalid columns in the rows sent, attempts to
@@ -111,9 +98,9 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
       }
     } catch (BigQueryException exception) {
       // Should only perform one table creation attempt.
-      if (isTableNotExistedException(exception) && autoCreateTables) {
+      if (BigQueryErrorResponses.isNonExistentTableError(exception) && autoCreateTables) {
         attemptTableCreate(tableId.getBaseTableId(), new ArrayList<>(rows.keySet()));
-      } else if (isTableMissingSchema(exception)) {
+      } else if (BigQueryErrorResponses.isTableMissingSchemaError(exception)) {
         attemptSchemaUpdate(tableId, new ArrayList<>(rows.keySet()));
       } else {
         throw exception;
@@ -186,9 +173,9 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     boolean invalidSchemaError = false;
     for (List<BigQueryError> errorList : errors.values()) {
       for (BigQueryError error : errorList) {
-        if (error.getReason().equals("invalid") && (error.getMessage().contains("no such field") || error.getMessage().contains("Missing required field"))) {
+        if (BigQueryErrorResponses.isMissingRequiredFieldError(error) || BigQueryErrorResponses.isUnrecognizedFieldError(error)) {
           invalidSchemaError = true;
-        } else if (!error.getReason().equals("stopped")) {
+        } else if (!BigQueryErrorResponses.isStoppedError(error)) {
           /* if some rows are in the old schema format, and others aren't, the old schema
            * formatted rows will show up as error: stopped. We still want to continue if this is
            * the case, because these errors don't represent a unique error if there are also

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Confluent, Inc.
+ *
+ * This software contains code derived from the WePay BigQuery Kafka Connector, Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.write.row;
+
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryException;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Handles the logic for classifying BigQuery error responses and determining things like whether they come from an
+ * invalid schema error, a backend error, etc. This can be used to determine whether a table needs to be created before
+ * retrying an insert or if a temporary server-side error requires us to retry a request, for example.
+ */
+public class BigQueryErrorResponses {
+
+  private static final int BAD_REQUEST_CODE = 400;
+  private static final int FORBIDDEN_CODE = 403;
+  private static final int NOT_FOUND_CODE = 404;
+  private static final int INTERNAL_SERVICE_ERROR_CODE = 500;
+  private static final int BAD_GATEWAY_CODE = 502;
+  private static final int SERVICE_UNAVAILABLE_CODE = 503;
+
+  private static final String BAD_REQUEST_REASON = "badRequest";
+  private static final String INVALID_REASON = "invalid"; 
+  private static final String NOT_FOUND_REASON = "notFound";
+  private static final String QUOTA_EXCEEDED_REASON = "quotaExceeded";
+  private static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
+  private static final String STOPPED_REASON = "stopped";
+
+
+  public static boolean isNonExistentTableError(BigQueryException exception) {
+    // If a table does not exist, it will raise a BigQueryException that the input is notFound
+    // Referring to Google Cloud Error Codes Doc: https://cloud.google.com/bigquery/docs/error-messages?hl=en
+    return NOT_FOUND_CODE == exception.getCode()
+        && NOT_FOUND_REASON.equals(exception.getReason())
+        && message(exception.getError()).startsWith("Not found: Table ");
+  }
+
+  public static boolean isTableMissingSchemaError(BigQueryException exception) {
+    // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
+    // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors
+    return BAD_REQUEST_CODE == exception.getCode()
+        && INVALID_REASON.equals(exception.getReason())
+        && message(exception.getError()).equals("The destination table has no schema.");
+  }
+
+  public static boolean isBackendError(BigQueryException exception) {
+    // backend error: https://cloud.google.com/bigquery/troubleshooting-errors
+    // for BAD_GATEWAY: https://cloud.google.com/storage/docs/json_api/v1/status-codes
+    // TODO: possibly this page is inaccurate for bigquery, but the message we are getting
+    //       suggest it's an internal backend error and we should retry, so lets take that at face
+    //       value
+    return INTERNAL_SERVICE_ERROR_CODE == exception.getCode()
+        || BAD_GATEWAY_CODE  == exception.getCode()
+        || SERVICE_UNAVAILABLE_CODE  == exception.getCode();
+  }
+
+  public static boolean isUnspecifiedBadRequestError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && exception.getError() == null
+        && exception.getReason() == null;
+  }
+
+  public static boolean isQuotaExceededError(BigQueryException exception) {
+    return FORBIDDEN_CODE == exception.getCode()
+        // TODO: May be able to use exception.getReason() instead of (indirectly) exception.getError().getReason()
+        //       Haven't been able to test yet though, so keeping as-is to avoid breaking anything
+        && QUOTA_EXCEEDED_REASON.equals(reason(exception.getError()));
+  }
+
+  public static boolean isRateLimitExceededError(BigQueryException exception) {
+    return FORBIDDEN_CODE == exception.getCode()
+        // TODO: May be able to use exception.getReason() instead of (indirectly) exception.getError().getReason()
+        //       Haven't been able to test yet though, so keeping as-is to avoid breaking anything
+        && RATE_LIMIT_EXCEEDED_REASON.equals(reason(exception.getError()));
+  }
+
+  public static boolean isRequestTooLargeError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && BAD_REQUEST_REASON.equals(exception.getReason())
+        && message(exception.getError()).startsWith("Request payload size exceeds the limit: ");
+  }
+
+  public static boolean isTooManyRowsError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && INVALID_REASON.equalsIgnoreCase(exception.getReason())
+        && message(exception.getError()).startsWith("too many rows present in the request");
+  }
+
+  public static boolean isUnrecognizedFieldError(BigQueryError error) {
+    return INVALID_REASON.equals(reason(error))
+        && message(error).startsWith("no such field: ");
+  }
+
+  public static boolean isMissingRequiredFieldError(BigQueryError error) {
+    return INVALID_REASON.equals(reason(error))
+        && message(error).startsWith("Missing required field: ");
+  }
+
+  public static boolean isStoppedError(BigQueryError error) {
+    return STOPPED_REASON.equals(reason(error))
+        && message(error).equals("");
+  }
+
+  private static String reason(BigQueryError error) {
+    return extractFromError(error, BigQueryError::getReason);
+  }
+
+  private static String message(BigQueryError error) {
+    return extractFromError(error, BigQueryError::getMessage);
+  }
+
+  private static String extractFromError(BigQueryError error, Function<BigQueryError, String> extraction) {
+    return Optional.ofNullable(error)
+        .map(extraction)
+        .orElse("");
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020 Confluent, Inc.
+ *
+ * This software contains code derived from the WePay BigQuery Kafka Connector, Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.integration;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import com.wepay.kafka.connect.bigquery.write.row.BigQueryErrorResponses;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.table;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BigQueryErrorResponsesIT extends BaseConnectorIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(BigQueryErrorResponsesIT.class);
+
+  private BigQuery bigQuery;
+
+  @Before
+  public void setup() {
+    bigQuery = newBigQuery();
+  }
+
+  @Test
+  public void testWriteToNonExistentTable() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("nonexistent table"));
+    TableClearer.clearTables(bigQuery, dataset(), table.getTable());
+
+    try {
+      bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
+      fail("Should have failed to write to nonexistent table");
+    } catch (BigQueryException e) {
+      logger.debug("Nonexistent table write error", e);
+      assertTrue(BigQueryErrorResponses.isNonExistentTableError(e));
+    }
+  }
+
+  @Test
+  public void testWriteToTableWithoutSchema() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("missing schema"));
+    createOrAssertSchemaMatches(table, Schema.of());
+
+    try {
+      bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
+      fail("Should have failed to write to table with no schema");
+    } catch (BigQueryException e) {
+      logger.debug("Table missing schema write error", e);
+      assertTrue(BigQueryErrorResponses.isTableMissingSchemaError(e));
+    }
+  }
+
+  @Test
+  public void testWriteWithMissingRequiredFields() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("too many fields"));
+    Schema schema = Schema.of(
+        Field.newBuilder("f1", StandardSQLTypeName.STRING).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f2", StandardSQLTypeName.INT64).setMode(Field.Mode.REQUIRED).build(),
+        Field.newBuilder("f3", StandardSQLTypeName.BOOL).setMode(Field.Mode.NULLABLE).build()
+    );
+    createOrAssertSchemaMatches(table, schema);
+
+    InsertAllResponse response = bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f2", 12L))));
+    logger.debug("Write response errors for missing required field: {}", response.getInsertErrors());
+    BigQueryError error = assertResponseHasSingleError(response);
+    assertTrue(BigQueryErrorResponses.isMissingRequiredFieldError(error));
+  }
+
+  @Test
+  public void testWriteWithUnrecognizedFields() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("not enough fields"));
+    Schema schema = Schema.of(
+        Field.newBuilder("f1", StandardSQLTypeName.STRING).setMode(Field.Mode.REQUIRED).build()
+    );
+    createOrAssertSchemaMatches(table, schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("f1", "v1");
+    row.put("f2", 12L);
+    InsertAllResponse response = bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(row)));
+    logger.debug("Write response errors for unrecognized field: {}", response.getInsertErrors());
+    BigQueryError error = assertResponseHasSingleError(response);
+    assertTrue(BigQueryErrorResponses.isUnrecognizedFieldError(error));
+  }
+
+  @Test
+  public void testStoppedRowsDuringInvalidWrite() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("not enough fields"));
+    Schema schema = Schema.of(
+        Field.newBuilder("f1", StandardSQLTypeName.STRING).setMode(Field.Mode.REQUIRED).build()
+    );
+    createOrAssertSchemaMatches(table, schema);
+
+    Map<String, Object> row1 = new HashMap<>();
+    row1.put("f1", "v1");
+    row1.put("f2", 12L);
+    Map<String, Object> row2 = Collections.singletonMap("f1", "v2");
+    InsertAllResponse response = bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(row1), RowToInsert.of(row2)));
+    logger.debug("Write response errors for unrecognized field and stopped row: {}", response.getInsertErrors());
+    assertEquals(2, response.getInsertErrors().size());
+    // As long as we have some kind of error on the first row it's fine; we want to be more precise in our assertions about the second row
+    assertListHasSingleElement(response.getErrorsFor(0));
+    BigQueryError secondRowError = assertListHasSingleElement(response.getErrorsFor(1));
+    assertTrue(BigQueryErrorResponses.isStoppedError(secondRowError));
+  }
+
+  @Test
+  public void testRequestPayloadTooLarge() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("request payload too large"));
+    Schema schema = Schema.of(
+        Field.newBuilder("f1", StandardSQLTypeName.STRING).setMode(Field.Mode.REQUIRED).build()
+    );
+    createOrAssertSchemaMatches(table, schema);
+
+    char[] chars = new char[10 * 1024 * 1024];
+    Arrays.fill(chars, '*');
+    String columnValue = new String(chars);
+    try {
+      bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", columnValue))));
+      fail("Should have failed to write to table with 11MB request");
+    } catch (BigQueryException e) {
+      logger.debug("Large request payload write error", e);
+      assertTrue(BigQueryErrorResponses.isRequestTooLargeError(e));
+    }
+  }
+
+  @Test
+  public void testTooManyRows() {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("too many rows"));
+    Schema schema = Schema.of(
+        Field.newBuilder("f1", StandardSQLTypeName.INT64).setMode(Field.Mode.REQUIRED).build()
+    );
+    createOrAssertSchemaMatches(table, schema);
+
+    Iterable<RowToInsert> rows = LongStream.range(0, 100_000)
+        .mapToObj(i -> Collections.singletonMap("f1", i))
+        .map(RowToInsert::of)
+        .collect(Collectors.toList());
+    try {
+      bigQuery.insertAll(InsertAllRequest.of(table, rows));
+      fail("Should have failed to write to table with 100,000 rows");
+    } catch (BigQueryException e) {
+      logger.debug("Too many rows write error", e);
+      assertTrue(BigQueryErrorResponses.isTooManyRowsError(e));
+    }
+  }
+
+  // Some tables can't be deleted, recreated, and written to without getting a temporary error from BigQuery,
+  // so we just create them once if they don't exist and don't delete them at the end of the test.
+  // If we detect a table left over (presumably from a prior test), we do a sanity check to make sure that it
+  // has the expected schema.
+  private void createOrAssertSchemaMatches(TableId tableId, Schema schema) {
+    Table table = bigQuery.getTable(tableId);
+    if (table == null) {
+      bigQuery.create(TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema)).build());
+    } else {
+      assertEquals(
+          String.format("Testing %s should be created automatically by tests; please delete the table and re-run this test", table(tableId)),
+          schema,
+          table.getDefinition().getSchema()
+      );
+    }
+  }
+
+  private BigQueryError assertResponseHasSingleError(InsertAllResponse response) {
+    assertEquals(1, response.getInsertErrors().size());
+    Iterator<List<BigQueryError>> errorsIterator = response.getInsertErrors().values().iterator();
+    assertTrue(errorsIterator.hasNext());
+    return assertListHasSingleElement(errorsIterator.next());
+  }
+
+  private <T> T assertListHasSingleElement(List<T> list) {
+    assertEquals(1, list.size());
+    return list.get(0);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -45,7 +45,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static com.google.cloud.bigquery.InsertAllRequest.RowToInsert;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -122,9 +122,11 @@ public class BigQueryWriterTest {
     when(insertAllResponse.hasErrors()).thenReturn(false);
     when(insertAllResponse.getInsertErrors()).thenReturn(emptyMap);
 
-    BigQueryException missTableException = new BigQueryException(404, "Table is missing");
+    String errorMessage = "Not found: Table project.scratch.test_topic";
+    BigQueryError error = new BigQueryError("notFound", "global", errorMessage);
+    BigQueryException nonExistentTableException = new BigQueryException(404, errorMessage, error); 
 
-    when(bigQuery.insertAll(anyObject())).thenThrow(missTableException).thenReturn(insertAllResponse);
+    when(bigQuery.insertAll(anyObject())).thenThrow(nonExistentTableException).thenReturn(insertAllResponse);
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/144

A new `BigQueryErrorResponses` class is added that isolates the logic for classifying error responses from BigQuery. Classes that used to perform their own error classification are updated to leverage this new class instead. An integration test suite is added for this new class that covers some but not all types of errors; some, such as backend errors and rate limit errors, are difficult or even impossible to test reliably.

The 2.0.x branch is targeted in order to leverage the new integration testing infrastructure introduced there. This can be backported to 1.6.x if there is significant demand and someone willing to file the PR.