### PR TITLE
GH-146: Parameterize BigQuerySinkConnectorIT tests

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -49,6 +49,7 @@ import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -116,13 +117,13 @@ public abstract class BaseConnectorIT {
 
   protected void stopConnect() {
     if (kafkaAdminClient !=  null) {
-      kafkaAdminClient.close();
+      Utils.closeQuietly(kafkaAdminClient, "admin client for embedded Kafka cluster");
       kafkaAdminClient = null;
     }
 
     // stop all Connect, Kafka and Zk threads.
     if (connect != null) {
-      connect.stop();
+      Utils.closeQuietly(connect::stop, "embedded Connect, Kafka, and Zookeeper clusters");
       connect = null;
     }
   }


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/146

This is a little more complicated than just adding the `@Parameterized` runner to the tests. Since they currently use a single embedded Zookeeper, Kafka, Connect, and Schema Registry worker that's shared among all test cases, the same behavior is preserved here in order to avoid inflating the build time with setting up/tearing down these services for each individual case.

Each test case now uses a different connector (to make it possible to run several test cases in a single build and get a more granular signal of success/failure for each of them), but they still share a single embedded instance of Connect, SR, etc.

In order to accomplish, the test class is modified to no longer inherit from `BaseConnectorIT` but to create and share a single static instance of it across test cases.