### PR TITLE
GH-149: Improve error messages on write thread failure

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -113,15 +113,8 @@ public class BigQuerySinkConnector extends SinkConnector {
   @Override
   public void start(Map<String, String> properties) {
     logger.trace("connector.start()");
-    try {
-      configProperties = properties;
-      config = new BigQuerySinkConfig(properties);
-    } catch (ConfigException err) {
-      throw new SinkConfigConnectException(
-          "Couldn't start BigQuerySinkConnector due to configuration error",
-          err
-      );
-    }
+    configProperties = properties;
+    config = new BigQuerySinkConfig(properties);
 
     if (!config.getBoolean(config.TABLE_CREATE_CONFIG)) {
       ensureExistingTables();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -187,7 +187,7 @@ public class BigQuerySinkTask extends SinkTask {
   @Override
   public void put(Collection<SinkRecord> records) {
     // Periodically poll for errors here instead of doing a stop-the-world check in flush()
-    executor.maybeThrowEncounteredErrors();
+    executor.maybeThrowEncounteredError();
 
     logger.debug("Putting {} records in the sink.", records.size());
 
@@ -326,14 +326,7 @@ public class BigQuerySinkTask extends SinkTask {
     logger.trace("task.start()");
     final boolean hasGCSBQTask =
         properties.remove(BigQuerySinkConnector.GCS_BQ_TASK_CONFIG_KEY) != null;
-    try {
-      config = new BigQuerySinkTaskConfig(properties);
-    } catch (ConfigException err) {
-      throw new SinkConfigConnectException(
-          "Couldn't start BigQuerySinkTask due to configuration error",
-          err
-      );
-    }
+    config = new BigQuerySinkTaskConfig(properties);
 
     bigQueryWriter = getBigQueryWriter();
     gcsToBQWriter = getGcsWriter();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -111,8 +111,17 @@ public class TableWriter implements Runnable {
 
   private static int getNewBatchSize(int currentBatchSize, Throwable err) {
     if (currentBatchSize == 1) {
-      // todo correct exception type?
-      throw new BigQueryConnectException("Attempted to reduce batch size below 1.", err);
+      logger.error("Attempted to reduce batch size below 1");
+      throw new BigQueryConnectException(
+          "Failed to write to BigQuery even after reducing batch size to 1 row at a time. "
+              + "This can indicate an error in the connector's logic for classifying BigQuery errors, as non-retriable"
+              + "errors may be being treated as retriable. "
+              + "If that appears to be the case, please report the issue to the project's maintainers and include the "
+              + "complete stack trace for this error as it appears in the logs. "
+              + "The cause of this exception is the error encountered from BigQuery after the last attempt to write a "
+              + "batch was made.",
+          err
+      );
     }
     // round batch size up so we don't end up with a dangling 1 row at the end.
     return (int) Math.ceil(currentBatchSize / 2.0);


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/149.

The `KCBQThreadPoolExecutor` is modified to only track one write thread exception at a time, which allows us to include a complete stack trace of that exception when failing the task.

The "Attempted to reduce batch size below 1." error is rewritten to include more information on a potential root cause and make the attached cause of the exception clearer.

Some cleanup of unnecessary exception wrapping when instantiating various `AbstractConfig` subclasses is also made.