### PR TITLE
adding table and column information to help debugging

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -53,7 +53,7 @@ public class BigQueryConnectException extends ConnectException {
     for (Map.Entry<Long, List<BigQueryError>> errorsEntry : errorsMap.entrySet()) {
       for (BigQueryError error : errorsEntry.getValue()) {
         messageBuilder.append(String.format(
-            "%n\t[row index %d]: %s: %s: %s",
+            "%n\t[row index %d] (location %s, reason: %s): %s",
             errorsEntry.getKey(),
             error.getLocation(),
             error.getReason(),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -53,8 +53,9 @@ public class BigQueryConnectException extends ConnectException {
     for (Map.Entry<Long, List<BigQueryError>> errorsEntry : errorsMap.entrySet()) {
       for (BigQueryError error : errorsEntry.getValue()) {
         messageBuilder.append(String.format(
-            "%n\t[row index %d]: %s: %s",
+            "%n\t[row index %d]: %s: %s: %s",
             errorsEntry.getKey(),
+            error.getLocation(),
             error.getReason(),
             error.getMessage()
         ));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -105,7 +105,7 @@ public abstract class BigQueryWriter {
                         List<InsertAllRequest.RowToInsert> rows,
                         String topic)
       throws BigQueryConnectException, BigQueryException, InterruptedException {
-    logger.info("writing {} row{} to table {}", rows.size(), rows.size() != 1 ? "s" : "", table);
+    logger.debug("writing {} row{} to table {}", rows.size(), rows.size() != 1 ? "s" : "", table);
 
     Exception mostRecentException = null;
     Map<Long, List<BigQueryError>> failedRowsMap = null;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -105,7 +105,7 @@ public abstract class BigQueryWriter {
                         List<InsertAllRequest.RowToInsert> rows,
                         String topic)
       throws BigQueryConnectException, BigQueryException, InterruptedException {
-    logger.debug("writing {} row{} to table {}", rows.size(), rows.size() != 1 ? "s" : "", table);
+    logger.info("writing {} row{} to table {}", rows.size(), rows.size() != 1 ? "s" : "", table);
 
     Exception mostRecentException = null;
     Map<Long, List<BigQueryError>> failedRowsMap = null;


### PR DESCRIPTION
The current logging information is hard to track which table and which column is related to BigQueryConnectException. This PR adds the table/column information to logs so that the error message would be more complete and easy to track. Would you please take a look at this small change? Thanks!