### PR TITLE
GH-45: Restore support for publishing to Maven Central (2.x.y only)

### DIFF
--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -34,6 +34,8 @@
 
     <properties>
         <main.dir>${project.parent.basedir}</main.dir>
+        <!-- Skip assembling the fat tar by default to reduce build time bloat -->
+        <skip.distribution.tar>true</skip.distribution.tar>
     </properties>
 
     <dependencies>
@@ -211,6 +213,42 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>tar-for-distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/release-tar.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <skipAssembly>${skip.distribution.tar}</skipAssembly>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skip.distribution.tar>false</skip.distribution.tar>
+            </properties>
+        </profile>
+        <profile>
+            <id>jenkins</id>
+            <properties>
+                <!-- We want to make sure in CI builds that the fat tar can be assembled -->
+                <skip.distribution.tar>false</skip.distribution.tar>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/kcbq-connector/src/assembly/release-tar.xml
+++ b/kcbq-connector/src/assembly/release-tar.xml
@@ -1,0 +1,17 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>release-tar</id>
+  <formats>
+    <format>tar</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -47,17 +47,23 @@
         <junit.version>4.13</junit.version>
         <mockito.version>3.2.4</mockito.version>
 
+        <assembly.plugin.version>3.3.0</assembly.plugin.version>
         <buildnumber.plugin.version>1.4</buildnumber.plugin.version>
         <checkstyle.plugin.version>2.15</checkstyle.plugin.version>
         <checkstyle.version>6.18</checkstyle.version>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
         <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
+        <javadoc.plugin.version>2.9.1</javadoc.plugin.version>
         <kafka.connect.plugin.version>0.11.1</kafka.connect.plugin.version>
         <release.plugin.version>2.5.3</release.plugin.version>
+        <signing.plugin.version>1.5</signing.plugin.version>
         <site.plugin.version>3.7.1</site.plugin.version>
+        <source.plugin.version>2.2.1</source.plugin.version>
         <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
 
         <main.dir>${project.basedir}</main.dir>
+        <!-- Skip GPG signing by default so that people can build locally without configuring a keyring, entering a passphrase, etc. -->
+        <skip.gpg.signing>true</skip.gpg.signing>
         <skip.unit.tests>${maven.test.skip}</skip.unit.tests>
     </properties>
 
@@ -106,6 +112,10 @@
             <id>jcenter</id>
             <url>https://jcenter.bintray.com</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -117,7 +127,22 @@
             <id>jcenter</id>
             <url>https://jcenter.bintray.com</url>
         </pluginRepository>
+        <pluginRepository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </pluginRepository>
     </pluginRepositories>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>
@@ -166,6 +191,12 @@
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-core</artifactId>
                 <version>${debezium.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.kafka</groupId>
+                        <artifactId>connect-transforms</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!--
@@ -313,6 +344,52 @@ under the License.
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${javadoc.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${signing.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                            <skip>${skip.gpg.signing}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -409,10 +486,21 @@ under the License.
                     <artifactId>kafka-connect-maven-plugin</artifactId>
                     <version>${kafka.connect.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${assembly.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
     <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skip.gpg.signing>false</skip.gpg.signing>
+            </properties>
+        </profile>
         <profile>
             <id>jenkins</id>
             <build>
@@ -452,6 +540,14 @@ under the License.
                                     <KCBQ_TEST_TABLE_SUFFIX>-${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_TABLE_SUFFIX>
                                     <KCBQ_TEST_FOLDER>${scmBranch}-${buildNumber}-${timestamp}</KCBQ_TEST_FOLDER>
                                 </environmentVariables>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-gpg-plugin</artifactId>
+                            <configuration>
+                                <keyname>${env.GPG_KEY}</keyname>
+                                <passphrase>${env.GPG_PASSPHRASE}</passphrase>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -503,6 +503,10 @@ under the License.
         </profile>
         <profile>
             <id>jenkins</id>
+            <properties>
+                <!-- We want to make sure in CI builds that artifacts can be signed -->
+                <skip.gpg.signing>false</skip.gpg.signing>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -503,10 +503,6 @@ under the License.
         </profile>
         <profile>
             <id>jenkins</id>
-            <properties>
-                <!-- We want to make sure in CI builds that artifacts can be signed -->
-                <skip.gpg.signing>false</skip.gpg.signing>
-            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Addresses https://github.com/confluentinc/kafka-connect-bigquery/issues/45 on 2.x.y branches only.

Adds support for publishing release artifacts (including a `kcbq-connector-<version>.tar` fat tar) to the project. Releases can now be performed by:

1. Checking out the to-be-released branch (if publishing a snapshot) or tag (if publishing an official release)
2. Running `mvn -P release clean deploy`, optionally including `-DskipTests` to speed up build time. Note that you may be prompted for a GPG key passphrase; you may enter that interactively during the build or, if running the build programmatically, by including the property `-Dgpg.passphrase=<passphrase>` in the maven command.
3. Examining the [snapshots](https://oss.sonatype.org/#view-repositories;snapshots) or [staging](https://oss.sonatype.org/#view-repositories;staging) (for official releases) Nexus repository to verify that the expected artifacts are present
4. (If performing an official release) closing and then promoting the staging repository to Maven Central (see detailed instructions [here](https://central.sonatype.org/publish/release/#close-and-drop-or-release-your-staging-repository))

Since artifacts must be signed in order to be eligible for release onto Maven Central, the GPG signing plugin is added to the build process. It's disabled by default but enabled when publishing releases. If issues arise with releases that appear to be related to artifact signing, the [docs for the signing plugin](https://maven.apache.org/plugins/maven-gpg-plugin/sign-mojo.html) may come in handy.

Since the `kcbq-confluent` artifact was removed in 2.0.0, the artifact ID for Maven central releases is changed to `kcbq-connector`. The group ID (`com.wepay.kcbq`) remains unchanged.