### PR TITLE
Log out the table name if could not write batch size

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -94,7 +94,7 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
-          logger.warn("Could not write batch of size {} to BigQuery table {}.", currentBatchList.size(),  table.getFullTableName(), err);
+          logger.warn("Could not write batch of size {} to BigQuery table {}.", currentBatchList.size(), table.getFullTableName(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -94,7 +94,7 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
-          logger.warn("Could not write batch of size {} to BigQuery.", currentBatchList.size(), err);
+          logger.warn("Could not write batch of size {} to BigQuery table {}.", currentBatchList.size(),  table.getFullTableName(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);


### PR DESCRIPTION
It is very difficult to check out which topic contains to oversize records with the current connector log. 