### PR TITLE
Add support for DG-410 Fix doc/defaults in Avro converter

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -29,7 +29,6 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,6 +55,8 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   public static final String MAP_VALUE_FIELD_NAME = "value";
 
   private static final Map<Schema.Type, LegacySQLTypeName> PRIMITIVE_TYPE_MAP;
+
+  private static final String AVRO_DOC_PARAMETER = "io.confluent.connect.avro.field.doc.";
 
   static {
     // force registration
@@ -178,6 +179,9 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
       setNullability(kafkaConnectSchema, res);
       if (kafkaConnectSchema.doc() != null) {
         res.setDescription(kafkaConnectSchema.doc());
+      } else if (kafkaConnectSchema.parameters() != null &&
+              kafkaConnectSchema.parameters().get(AVRO_DOC_PARAMETER + fieldName) != null){
+        res.setDescription(kafkaConnectSchema.parameters().get(AVRO_DOC_PARAMETER + fieldName));
       }
       return res;
     });

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -609,6 +609,30 @@ public class BigQuerySchemaConverterTest {
     assertEquals(bigQueryExpectedSchema, bigQueryTestSchema);
   }
 
+    @Test
+    public void testDescriptionInField() {
+        final String fieldName = "WithDoc";
+        final String fieldDoc = "test documentation";
+
+        com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
+                com.google.cloud.bigquery.Schema.of(
+                        com.google.cloud.bigquery.Field.newBuilder(fieldName,
+                                LegacySQLTypeName.STRING)
+                                .setMode(com.google.cloud.bigquery.Field.Mode.REQUIRED)
+                                .setDescription(fieldDoc)
+                                .build()
+                );
+
+        Schema kafkaConnectTestSchema =
+                SchemaBuilder.struct()
+                        .field(fieldName, SchemaBuilder.string().parameter("io.confluent.connect.avro.field.doc." + fieldName,fieldDoc).build())
+                        .build();
+
+        com.google.cloud.bigquery.Schema bigQueryTestSchema =
+                new BigQuerySchemaConverter(false).convertSchema(kafkaConnectTestSchema);
+        assertEquals(bigQueryExpectedSchema, bigQueryTestSchema);
+    }
+
   @Test
   public void testAllFieldsNullable() {
     final String fieldName = "RequiredField";


### PR DESCRIPTION
## What

Avro has moved their doc strings from field().doc() to parameters, where the parameter name is `io.confluent.connect.avro.field.doc.` fieldName. To adjust to this, if doc is absent, let's look for this parameter and populate the doc string accordingly. 


This is a fix for https://confluentinc.atlassian.net/browse/RCCA-4012