### PR TITLE
MINOR: Handle new "table is deleted" error from BigQuery

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
@@ -48,11 +48,12 @@ public class BigQueryErrorResponses {
 
 
   public static boolean isNonExistentTableError(BigQueryException exception) {
+    String message = message(exception.getError());
     // If a table does not exist, it will raise a BigQueryException that the input is notFound
     // Referring to Google Cloud Error Codes Doc: https://cloud.google.com/bigquery/docs/error-messages?hl=en
     return NOT_FOUND_CODE == exception.getCode()
         && NOT_FOUND_REASON.equals(exception.getReason())
-        && message(exception.getError()).startsWith("Not found: Table ");
+        && (message.startsWith("Not found: Table ") || message.contains("Table is deleted: "));
   }
 
   public static boolean isTableMissingSchemaError(BigQueryException exception) {


### PR DESCRIPTION
Previously, if a table was deleted and recreated in a short time period, some writes to that table ran the risk of being silently dropped by BigQuery.

It seems like BigQuery handles that case now by returning a new error for writes to recently-recreated tables with the same 404 code and `notFound` reason, but a slightly different message (something like "Not found: table Table is deleted: &lt;table&gt;" (the "table Table" part is not a typo; this is what the responses actually look like)).

We can handle this new error the same way we handle missing table errors already. It may not be super useful for everyday users of the connector but it makes integration testing (and possibly upsert/delete logic) much easier since we can now wipe out tables left over from previous tests and then spin up connector instances that write to them immediately after.

Depended on by https://github.com/confluentinc/kafka-connect-bigquery/pull/141/