### PR TITLE
Support Application Default Credentials (ADC) to find credentials automatically in GCP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ common {
   publish = false
   downStreamValidate = false
   secret_file_list = [
-          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE']
+          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE'],
+          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'GOOGLE_APPLICATION_CREDENTIALS']
   ]
 }

--- a/README.md
+++ b/README.md
@@ -156,13 +156,8 @@ You must supply the following environment variables in order to run the tests:
 
 - `$KCBQ_TEST_PROJECT`: The name of the BigQuery project to use for the test
 - `$KCBQ_TEST_DATASET`: The name of the BigQuery dataset to use for the test
-- `$KCBQ_TEST_KEYFILE`: The key (either file or raw contents) used to authenticate with BigQuery
-during the test
+- `$KCBQ_TEST_KEYFILE`: The key file used to authenticate with BigQuery during the test
 - `$KCBQ_TEST_BUCKET`: The name of the GCS bucket to use (for testing the GCS batch loading feature)
-
-Optionally, the `$KCBQ_TEST_KEYSOURCE` variable can be supplied to specify whether the value of
-`$KCBQ_TEST_KEYFILE` is a path to a key file (if set to `FILE`) or the raw contents of a key file
-(if set to `JSON`). The default is `FILE`.
 
 The `$KCBQ_TEST_FOLDER` variable can be supplied to specify which subfolder of the GCS bucket should
 be used when testing the GCS batch loading feature; if not supplied, the top-level folder will be

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
@@ -41,7 +41,7 @@ import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.PROJECT
 public abstract class GcpClientBuilder<Client> {
 
   public enum KeySource {
-    FILE, JSON
+    FILE, JSON, SERVICE_ACCOUNT
   }
 
   private static final Logger logger = LoggerFactory.getLogger(GcpClientBuilder.class);
@@ -78,7 +78,7 @@ public abstract class GcpClientBuilder<Client> {
   }
 
   private GoogleCredentials credentials() {
-    if (key == null) {
+    if (key == null && keySource != KeySource.SERVICE_ACCOUNT) {
       return null;
     }
 
@@ -98,6 +98,13 @@ public abstract class GcpClientBuilder<Client> {
           throw new BigQueryConnectException("Failed to access JSON key file", e);
         }
         break;
+      case SERVICE_ACCOUNT:
+        try {
+          logger.debug("Attempting to use the service account");
+          return GoogleCredentials.getApplicationDefault();
+        } catch (IOException e) {
+          throw new BigQueryConnectException("Failed to create Application Default Credentials", e);
+        }
       default:
         throw new IllegalArgumentException("Unexpected value for KeySource enum: " + keySource);
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
@@ -100,7 +100,7 @@ public abstract class GcpClientBuilder<Client> {
         break;
       case SERVICE_ACCOUNT:
         try {
-          logger.debug("Attempting to use the service account");
+          logger.debug("Attempting to use application default credentials");
           return GoogleCredentials.getApplicationDefault();
         } catch (IOException e) {
           throw new BigQueryConnectException("Failed to create Application Default Credentials", e);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
@@ -41,7 +41,7 @@ import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.PROJECT
 public abstract class GcpClientBuilder<Client> {
 
   public enum KeySource {
-    FILE, JSON, SERVICE_ACCOUNT
+    FILE, JSON, APPLICATION_DEFAULT
   }
 
   private static final Logger logger = LoggerFactory.getLogger(GcpClientBuilder.class);
@@ -78,7 +78,7 @@ public abstract class GcpClientBuilder<Client> {
   }
 
   private GoogleCredentials credentials() {
-    if (key == null && keySource != KeySource.SERVICE_ACCOUNT) {
+    if (key == null && keySource != KeySource.APPLICATION_DEFAULT) {
       return null;
     }
 
@@ -98,7 +98,7 @@ public abstract class GcpClientBuilder<Client> {
           throw new BigQueryConnectException("Failed to access JSON key file", e);
         }
         break;
-      case SERVICE_ACCOUNT:
+      case APPLICATION_DEFAULT:
         try {
           logger.debug("Attempting to use application default credentials");
           return GoogleCredentials.getApplicationDefault();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -148,7 +148,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance KEY_SOURCE_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String KEY_SOURCE_DOC =
           "Determines whether the keyfile config is the path to the credentials json, the json itself " +
-                  "or a service account (only in GCP)";
+                  "or it is not provided as Application Default Credentials (ADC) are used.";
 
   public static final String SANITIZE_TOPICS_CONFIG =                     "sanitizeTopics";
   private static final ConfigDef.Type SANITIZE_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -147,7 +147,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   );
   private static final ConfigDef.Importance KEY_SOURCE_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String KEY_SOURCE_DOC =
-          "Determines whether the keyfile config is the path to the credentials json, or the json itself";
+          "Determines whether the keyfile config is the path to the credentials json, the json itself " +
+                  "or a service account (only in GCP)";
 
   public static final String SANITIZE_TOPICS_CONFIG =                     "sanitizeTopics";
   private static final ConfigDef.Type SANITIZE_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -147,8 +147,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
   );
   private static final ConfigDef.Importance KEY_SOURCE_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String KEY_SOURCE_DOC =
-          "Determines whether the keyfile config is the path to the credentials json, the json itself " +
-                  "or it is not provided as Application Default Credentials (ADC) are used.";
+          "Determines whether the " + KEYFILE_CONFIG + " config is the path to the credentials json file "
+              + "or the raw json of the key itself. "
+              + "If set to " + GcpClientBuilder.KeySource.APPLICATION_DEFAULT.name() + ", the "
+              + KEYFILE_CONFIG + " should not be provided and the connector will use any GCP "
+              + "application default credentials that it can find on the Connect worker for authentication.";
 
   public static final String SANITIZE_TOPICS_CONFIG =                     "sanitizeTopics";
   private static final ConfigDef.Type SANITIZE_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
@@ -47,7 +47,7 @@ public abstract class CredentialsValidator<ClientBuilder extends GcpClientBuilde
       PROJECT_CONFIG, KEY_SOURCE_CONFIG
   ));
 
-  public static final String ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC = KEYFILE_CONFIG + " should not be"
+  public static final String ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC = KEYFILE_CONFIG + " should not be "
           + "provided if " + KEY_SOURCE_CONFIG + " is " + KeySource.APPLICATION_DEFAULT;
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
@@ -54,7 +54,7 @@ public abstract class CredentialsValidator<ClientBuilder extends GcpClientBuilde
   @Override
   protected Optional<String> doValidate(BigQuerySinkConfig config) {
     String keyFile = config.getKey();
-    if (keyFile == null || keyFile.isEmpty()) {
+    if (keyFile == null || keyFile.isEmpty() || config.getKeySource() == GcpClientBuilder.KeySource.SERVICE_ACCOUNT) {
       // No credentials to validate
       return Optional.empty();
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
@@ -47,9 +47,6 @@ public abstract class CredentialsValidator<ClientBuilder extends GcpClientBuilde
       PROJECT_CONFIG, KEY_SOURCE_CONFIG
   ));
 
-  public static final String ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC = KEYFILE_CONFIG + " should not be "
-          + "provided if " + KEY_SOURCE_CONFIG + " is " + KeySource.APPLICATION_DEFAULT;
-
   @Override
   protected Collection<String> dependents() {
     return DEPENDENTS;
@@ -61,7 +58,9 @@ public abstract class CredentialsValidator<ClientBuilder extends GcpClientBuilde
     KeySource keySource = config.getKeySource();
 
     if (keySource == KeySource.APPLICATION_DEFAULT && keyFile != null  && !keyFile.isEmpty()) {
-      return Optional.of(ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC);
+      String errorMessage = KEYFILE_CONFIG + " should not be provided if " + KEY_SOURCE_CONFIG
+              + " is " + KeySource.APPLICATION_DEFAULT;
+      return Optional.of(errorMessage);
     }
 
     if ((keyFile == null || keyFile.isEmpty()) && config.getKeySource() != GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidator.java
@@ -64,7 +64,7 @@ public abstract class CredentialsValidator<ClientBuilder extends GcpClientBuilde
       return Optional.of(ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC);
     }
 
-    if ( (keyFile == null || keyFile.isEmpty()) && config.getKeySource() != GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
+    if ((keyFile == null || keyFile.isEmpty()) && config.getKeySource() != GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
       // No credentials to validate
       return Optional.empty();
     }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
@@ -69,18 +69,6 @@ public class CredentialsValidatorTest {
   }
 
   @Test
-  public void testApplicationDefaultCredentials() {
-    BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
-    when(config.getKey()).thenReturn(null);
-    when(config.getKeySource()).thenReturn(GcpClientBuilder.KeySource.APPLICATION_DEFAULT);
-
-    assertNotEquals(
-            Optional.empty(),
-            new CredentialsValidator.BigQueryCredentialsValidator().doValidate(config)
-    );
-  }
-
-  @Test
   public void testKeyShouldNotBeProvidedIfUsingApplicationDefaultCredentials() {
     BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
     when(config.getKey()).thenReturn("key");

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 
 import java.util.Optional;
 
-import static com.wepay.kafka.connect.bigquery.config.CredentialsValidator.ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -86,9 +86,9 @@ public class CredentialsValidatorTest {
     when(config.getKey()).thenReturn("key");
     when(config.getKeySource()).thenReturn(GcpClientBuilder.KeySource.APPLICATION_DEFAULT);
 
-    assertEquals(
-            Optional.of(ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC),
+    assertTrue(
             new CredentialsValidator.BigQueryCredentialsValidator().doValidate(config)
+                    .get().contains("should not be provided")
     );
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/CredentialsValidatorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static com.wepay.kafka.connect.bigquery.config.CredentialsValidator.ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,6 +65,30 @@ public class CredentialsValidatorTest {
     assertNotEquals(
         Optional.empty(),
         new CredentialsValidator.GcsCredentialsValidator().doValidate(config)
+    );
+  }
+
+  @Test
+  public void testApplicationDefaultCredentials() {
+    BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+    when(config.getKey()).thenReturn(null);
+    when(config.getKeySource()).thenReturn(GcpClientBuilder.KeySource.APPLICATION_DEFAULT);
+
+    assertNotEquals(
+            Optional.empty(),
+            new CredentialsValidator.BigQueryCredentialsValidator().doValidate(config)
+    );
+  }
+
+  @Test
+  public void testKeyShouldNotBeProvidedIfUsingApplicationDefaultCredentials() {
+    BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+    when(config.getKey()).thenReturn("key");
+    when(config.getKeySource()).thenReturn(GcpClientBuilder.KeySource.APPLICATION_DEFAULT);
+
+    assertEquals(
+            Optional.of(ERROR_MESSAGE_KEY_SHOULD_NOT_BE_PROVIDED_IF_ADC),
+            new CredentialsValidator.BigQueryCredentialsValidator().doValidate(config)
     );
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -80,7 +80,6 @@ public abstract class BaseConnectorIT {
   private static final String KEYFILE_ENV_VAR = "KCBQ_TEST_KEYFILE";
   private static final String PROJECT_ENV_VAR = "KCBQ_TEST_PROJECT";
   private static final String DATASET_ENV_VAR = "KCBQ_TEST_DATASET";
-  private static final String KEYSOURCE_ENV_VAR = "KCBQ_TEST_KEYSOURCE";
   private static final String GCS_BUCKET_ENV_VAR = "KCBQ_TEST_BUCKET";
   private static final String GCS_FOLDER_ENV_VAR = "KCBQ_TEST_FOLDER";
   private static final String TEST_NAMESPACE_ENV_VAR = "KCBQ_TEST_TABLE_SUFFIX";
@@ -370,7 +369,7 @@ public abstract class BaseConnectorIT {
   }
 
   protected String keySource() {
-    return readEnvVar(KEYSOURCE_ENV_VAR, BigQuerySinkConfig.KEY_SOURCE_DEFAULT);
+    return BigQuerySinkConfig.KEY_SOURCE_DEFAULT;
   }
 
   protected String gcsBucket() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
@@ -27,7 +27,8 @@ public class GcpClientBuilderIT extends BaseConnectorIT {
             properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, null);
         }
         else if (keySource == GcpClientBuilder.KeySource.JSON){
-            // actually keySource is the path to the credentials file, so we convert it to the json string
+            // actually keyFile is the path to the credentials file, so we convert it to the json string
+
             String credentialsJsonString = new String(Files.readAllBytes(Paths.get(keyFile())), StandardCharsets.UTF_8);
             properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, credentialsJsonString);
         }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
@@ -22,7 +22,8 @@ public class GcpClientBuilderIT extends BaseConnectorIT {
         Map<String, String> properties = baseConnectorProps(1);
         properties.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource.name());
 
-        if(keySource == GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
+        if (keySource == GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
+
             properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, null);
         }
         else if (keySource == GcpClientBuilder.KeySource.JSON){

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
@@ -1,0 +1,67 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.storage.Storage;
+import com.wepay.kafka.connect.bigquery.GcpClientBuilder;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+@Category(IntegrationTest.class)
+public class GcpClientBuilderIT extends BaseConnectorIT {
+
+    private BigQuerySinkConfig connectorProps(GcpClientBuilder.KeySource keySource) throws IOException {
+        Map<String, String> properties = baseConnectorProps(1);
+        properties.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource.name());
+
+        if(keySource == GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
+            properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, null);
+        }
+        else if (keySource == GcpClientBuilder.KeySource.JSON){
+            // actually keySource is the path to the credentials file, so we convert it to the json string
+            String credentialsJsonString = new String(Files.readAllBytes(Paths.get(keyFile())), StandardCharsets.UTF_8);
+            properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, credentialsJsonString);
+        }
+
+        return new BigQuerySinkConfig(properties);
+    }
+
+    /**
+     * Construct the BigQuery and Storage clients and perform some basic operations to check they are operational.
+     * @param keySource the key Source to use
+     * @throws IOException
+     */
+    private void testClients(GcpClientBuilder.KeySource keySource) throws IOException {
+        BigQuerySinkConfig config = connectorProps(keySource);
+
+        BigQuery bigQuery = new GcpClientBuilder.BigQueryBuilder().withConfig(config).build();
+        Storage storage = new GcpClientBuilder.GcsBuilder().withConfig(config).build();
+
+        bigQuery.listTables(DatasetId.of(dataset()));
+        storage.get(gcsBucket());
+    }
+
+    @Test
+    public void testApplicationDefaultCredentials() throws IOException {
+        testClients(GcpClientBuilder.KeySource.APPLICATION_DEFAULT);
+    }
+
+    @Test
+    public void testFile() throws IOException {
+        testClients(GcpClientBuilder.KeySource.FILE);
+    }
+
+    @Test
+    public void testJson() throws IOException {
+        testClients(GcpClientBuilder.KeySource.JSON);
+    }
+
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
@@ -23,12 +23,10 @@ public class GcpClientBuilderIT extends BaseConnectorIT {
         properties.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource.name());
 
         if (keySource == GcpClientBuilder.KeySource.APPLICATION_DEFAULT) {
-
             properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, null);
         }
         else if (keySource == GcpClientBuilder.KeySource.JSON){
             // actually keyFile is the path to the credentials file, so we convert it to the json string
-
             String credentialsJsonString = new String(Files.readAllBytes(Paths.get(keyFile())), StandardCharsets.UTF_8);
             properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, credentialsJsonString);
         }


### PR DESCRIPTION
Support Application Default Credentials (ADC) to allow finding credentials automatically if deployed in GCP.

If kafka connect runs inside a Google Cloud environment, is possible to attach a service account to that environment, so the application can retrieve credentials for the service account without having to create and manage keys. 

https://cloud.google.com/docs/authentication/production

Its also possible to use this method outside GCP by setting the **GOOGLE_APPLICATION_CREDENTIALS** env var with the path to the credentials file.