### PR TITLE
Retry on IOExceptions thrown during table writes

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -94,7 +94,10 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
-          logger.warn("Could not write batch of size {} to BigQuery. (Error code {})", currentBatchList.size(), err.getCode(), err);
+          logger.warn(
+              "Could not write batch of size {} to BigQuery. "
+                  + "Error code: {}, underlying error (if present): {}",
+              currentBatchList.size(), err.getCode(), err.getError(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -94,7 +94,7 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
-          logger.warn("Could not write batch of size {} to BigQuery.", currentBatchList.size(), err);
+          logger.warn("Could not write batch of size {} to BigQuery. (Error code {})", currentBatchList.size(), err.getCode(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize, err);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
@@ -22,6 +22,7 @@ package com.wepay.kafka.connect.bigquery.write.row;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -40,7 +41,7 @@ public class BigQueryErrorResponses {
   private static final int SERVICE_UNAVAILABLE_CODE = 503;
 
   private static final String BAD_REQUEST_REASON = "badRequest";
-  private static final String INVALID_REASON = "invalid"; 
+  private static final String INVALID_REASON = "invalid";
   private static final String NOT_FOUND_REASON = "notFound";
   private static final String QUOTA_EXCEEDED_REASON = "quotaExceeded";
   private static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
@@ -105,6 +106,11 @@ public class BigQueryErrorResponses {
     return BAD_REQUEST_CODE == exception.getCode()
         && INVALID_REASON.equalsIgnoreCase(exception.getReason())
         && message(exception.getError()).startsWith("too many rows present in the request");
+  }
+
+  public static boolean isIOError(BigQueryException error) {
+    return BigQueryException.UNKNOWN_CODE == error.getCode()
+        && error.getCause() instanceof IOException;
   }
 
   public static boolean isUnrecognizedFieldError(BigQueryError error) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -30,7 +30,6 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -43,8 +42,6 @@ import java.util.TreeMap;
  * A class for writing lists of rows to a BigQuery table.
  */
 public abstract class BigQueryWriter {
-
-  private static final int UNKNOWN_CODE = BigQueryException.UNKNOWN_CODE;
 
   private static final int WAIT_MAX_JITTER = 1000;
 
@@ -138,8 +135,7 @@ public abstract class BigQueryWriter {
         } else if (BigQueryErrorResponses.isRateLimitExceededError(err)) {
           logger.warn("Rate limit exceeded for table {}, attempting retry", table);
           retryCount++;
-        } else if (err.getCode() == UNKNOWN_CODE && err.getCause() != null && err.getCause() instanceof IOException){
-          //Retry when IO exceptions occur
+        } else if (BigQueryErrorResponses.isIOError(err)){
           logger.warn("IO Exception: {}, attempting retry", err.getCause().getMessage());
           retryCount++;
         } else {


### PR DESCRIPTION
Currently if an IOException is thrown (such as due to network interruption) the writer will not retry the write and will instead fail the task.

Instead, catch the IOException case and retry the put.

Supersedes #122 from @rikusg and applies the suggested changes from code review.