### PR TITLE
Added user-agent header for GCP calls

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,4 +26,5 @@ common {
           ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE'],
           ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'GOOGLE_APPLICATION_CREDENTIALS']
   ]
+  timeoutHours = 2
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -458,11 +458,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "older than the specified partition expiration time will be permanently deleted. "
           + "Existing tables will not be altered to use this partition expiration time.";
 
-  public static final String GCP_CONNECTOR_PROVIDER_CONFIG = "provider";
-  private static final ConfigDef.Type GCP_CONNECTOR_PROVIDER_TYPE = ConfigDef.Type.STRING;
-  public static final String GCP_CONNECTOR_PROVIDER_DEFAULT = "Confluent Platform";
-  private static final ConfigDef.Importance GCP_CONNECTOR_PROVIDER_IMPORTANCE = ConfigDef.Importance.LOW;
-  public static final List<String> GCP_CONNECTOR_PROVIDER_TYPES = Stream.of("Confluent Platform", "Confluent Cloud")
+  //This config determines where the connector is hosted (Confluent Cloud or Confluent Platform).
+  //This is not enforced and defaulted to "Confluent Platform". Currently, it is only used for user-agent tracking in GCP.
+  public static final String CONNECTOR_RUNTIME_PROVIDER_CONFIG = "runtimeProvider";
+  private static final ConfigDef.Type CONNECTOR_RUNTIME_PROVIDER_TYPE = ConfigDef.Type.STRING;
+  public static final String CONNECTOR_RUNTIME_PROVIDER_DEFAULT = "Confluent Platform";
+  private static final ConfigDef.Importance CONNECTOR_RUNTIME_PROVIDER_IMPORTANCE = ConfigDef.Importance.LOW;
+  public static final List<String> CONNECTOR_RUNTIME_PROVIDER_TYPES = Stream.of("Confluent Platform", "Confluent Cloud")
           .collect(Collectors.toList());
 
   /**
@@ -746,10 +748,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE,
             BIGQUERY_PARTITION_EXPIRATION_DOC
         ).defineInternal(
-            GCP_CONNECTOR_PROVIDER_CONFIG,
-            GCP_CONNECTOR_PROVIDER_TYPE,
-            GCP_CONNECTOR_PROVIDER_DEFAULT,
-            GCP_CONNECTOR_PROVIDER_IMPORTANCE
+                    CONNECTOR_RUNTIME_PROVIDER_CONFIG,
+                    CONNECTOR_RUNTIME_PROVIDER_TYPE,
+                    CONNECTOR_RUNTIME_PROVIDER_DEFAULT,
+                    CONNECTOR_RUNTIME_PROVIDER_IMPORTANCE
         );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -458,12 +458,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "older than the specified partition expiration time will be permanently deleted. "
           + "Existing tables will not be altered to use this partition expiration time.";
 
-  public static final String GCP_CONNECTOR_USER_AGENT_CONFIG = "bigQueryUserAgent";
-  private static final ConfigDef.Type GCP_CONNECTOR_USER_AGENT_TYPE = ConfigDef.Type.STRING;
-  private static final String GCP_CONNECTOR_USER_AGENT_DEFAULT = "Confluent Platform";
-  private static final ConfigDef.Importance GCP_CONNECTOR_USER_AGENT_IMPORTANCE = ConfigDef.Importance.LOW;
-  private static final String GCP_CONNECTOR_USER_AGENT_DOC =
-          "User Agent header value for GCP. This is for GCP to track usage for this connector.";
+  public static final String GCP_CONNECTOR_PROVIDER_CONFIG = "provider";
+  private static final ConfigDef.Type GCP_CONNECTOR_PROVIDER_TYPE = ConfigDef.Type.STRING;
+  public static final String GCP_CONNECTOR_PROVIDER_DEFAULT = "Confluent Platform";
+  private static final ConfigDef.Importance GCP_CONNECTOR_PROVIDER_IMPORTANCE = ConfigDef.Importance.LOW;
+  public static final List<String> GCP_CONNECTOR_PROVIDER_TYPES = Stream.of("Confluent Platform", "Confluent Cloud")
+          .collect(Collectors.toList());
 
   /**
    * Return the ConfigDef object used to define this config's fields.
@@ -745,12 +745,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_PARTITION_EXPIRATION_VALIDATOR,
             BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE,
             BIGQUERY_PARTITION_EXPIRATION_DOC
-        ).define(
-            GCP_CONNECTOR_USER_AGENT_CONFIG,
-            GCP_CONNECTOR_USER_AGENT_TYPE,
-            GCP_CONNECTOR_USER_AGENT_DEFAULT,
-            GCP_CONNECTOR_USER_AGENT_IMPORTANCE,
-            GCP_CONNECTOR_USER_AGENT_DOC);
+        ).defineInternal(
+            GCP_CONNECTOR_PROVIDER_CONFIG,
+            GCP_CONNECTOR_PROVIDER_TYPE,
+            GCP_CONNECTOR_PROVIDER_DEFAULT,
+            GCP_CONNECTOR_PROVIDER_IMPORTANCE
+        );
   }
 
   private static final List<MultiPropertyValidator<BigQuerySinkConfig>> MULTI_PROPERTY_VALIDATIONS = new ArrayList<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -458,6 +458,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "older than the specified partition expiration time will be permanently deleted. "
           + "Existing tables will not be altered to use this partition expiration time.";
 
+  public static final String GCP_CONNECTOR_USER_AGENT_CONFIG = "bigQueryUserAgent";
+  private static final ConfigDef.Type GCP_CONNECTOR_USER_AGENT_TYPE = ConfigDef.Type.STRING;
+  private static final String GCP_CONNECTOR_USER_AGENT_DEFAULT = "Confluent Platform";
+  private static final ConfigDef.Importance GCP_CONNECTOR_USER_AGENT_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String GCP_CONNECTOR_USER_AGENT_DOC =
+          "User Agent header value for GCP. This is for GCP to track usage for this connector.";
+
   /**
    * Return the ConfigDef object used to define this config's fields.
    *
@@ -738,7 +745,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_PARTITION_EXPIRATION_VALIDATOR,
             BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE,
             BIGQUERY_PARTITION_EXPIRATION_DOC
-        );
+        ).define(
+            GCP_CONNECTOR_USER_AGENT_CONFIG,
+            GCP_CONNECTOR_USER_AGENT_TYPE,
+            GCP_CONNECTOR_USER_AGENT_DEFAULT,
+            GCP_CONNECTOR_USER_AGENT_IMPORTANCE,
+            GCP_CONNECTOR_USER_AGENT_DOC);
   }
 
   private static final List<MultiPropertyValidator<BigQuerySinkConfig>> MULTI_PROPERTY_VALIDATIONS = new ArrayList<>();

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.CONNECTOR_RUNTIME_PROVIDER_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.CONNECTOR_RUNTIME_PROVIDER_DEFAULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -213,5 +215,21 @@ public class BigQuerySinkConfigTest {
 
     configProperties.put(BigQuerySinkConfig.TIME_PARTITIONING_TYPE_CONFIG, "fortnight");
     new BigQuerySinkConfig(configProperties);
+  }
+
+  @Test
+  public void testKafkaProviderConfigDefaultValue() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertEquals(CONNECTOR_RUNTIME_PROVIDER_DEFAULT, config.getString(CONNECTOR_RUNTIME_PROVIDER_CONFIG));
+  }
+
+  @Test
+  public void testKafkaProviderConfig() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    String testKafkaProvider = "testProvider";
+    configProperties.put(CONNECTOR_RUNTIME_PROVIDER_CONFIG, testKafkaProvider);
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertEquals(testKafkaProvider, config.getString(CONNECTOR_RUNTIME_PROVIDER_CONFIG));
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -148,6 +148,7 @@ public abstract class BaseConnectorIT {
         .withKey(keyFile())
         .withKeySource(GcpClientBuilder.KeySource.valueOf(keySource()))
         .withProject(project())
+        .withUserAgent("ITTest-user-agent")
         .build();
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -117,7 +117,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
           // Try to write to it...
           try {
             bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
-            return false;
+            return true;
           } catch (BigQueryException e) {
             logger.debug("Recreated table write error", e);
             return BigQueryErrorResponses.isNonExistentTableError(e);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -275,7 +275,7 @@ public class BigQueryWriterTest {
     testTask.put(sinkRecordList);
     Exception expectedEx =  assertThrows(BigQueryConnectException.class, 
                                         () -> testTask.flush(Collections.emptyMap())); 
-    assertTrue(expectedEx.getMessage().contains("test_topic"));
+    assertTrue(expectedEx.getCause().getMessage().contains("test_topic"));
   }
   /**
    * Utility method for making and retrieving properties based on provided parameters.


### PR DESCRIPTION
## Problem
User-agent Header needs to be added for GCP calls from the connector to track connector usage.

## Solution
We have created an internal config for Product name. We will use this config to populate the appropriate product in the header.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
