### PR TITLE
Fixed test and increased jenkins timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,4 +25,5 @@ common {
   secret_file_list = [
           ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE']
   ]
+  timeoutHours = 2
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -117,7 +117,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
           // Try to write to it...
           try {
             bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
-            return false;
+            return true;
           } catch (BigQueryException e) {
             logger.debug("Recreated table write error", e);
             return BigQueryErrorResponses.isNonExistentTableError(e);


### PR DESCRIPTION
## Problem
The jenkins build was failing as it takes more than 1 hour with the new versions (2.x.x)

## Solution
Increased the timeout to 2 hours in jenkins file.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
