### PR TITLE
Use `batch` priority for intermediate table DELETEs

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -155,7 +155,9 @@ public class MergeQueries {
     logger.trace("Clearing batches from {} on back from {}", batchNumber, intTable(intermediateTable));
     String batchClearQuery = batchClearQuery(intermediateTable, batchNumber);
     logger.trace(batchClearQuery);
-    bigQuery.query(QueryJobConfiguration.of(batchClearQuery));
+    // Run in `batch` priority to reduce the number of concurrent `interactive` queries.
+    // `Interactive` queries count against concurrent BigQuery limits, whereas `batch` queries do not.
+    bigQuery.query(QueryJobConfiguration.newBuilder(batchClearQuery).setPriority(QueryJobConfiguration.Priority.BATCH).build());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
For configurations with many bigquery connectors, such as debezium
change data capture pipelines that replicate 100s of tables to BigQuery,
execute `DELETE`s of the intermediate tables in `batch` priority. This reduces
the number of `interactive` queries running concurrently in BigQuery and
lowers the likelihood of hitting BigQuery limits on concurrent queries.

Since the intermediate table clearing is done on a best effort basis
and since the code is already built to handle stale data in the table,
(such as cases where the data is in the temp streaming buffer, that
DELETES cannot affect), we can safely queue up batch based DELETEs.