### PR TITLE
Handle request too big exception dynamically (when request above 10MB) 

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -113,8 +113,8 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
 
         Map<Boolean, SortedMap<SinkRecord, InsertAllRequest.RowToInsert>> collect = splitRowsInTwo(rows);
 
-        logger.warn("Request to `" + tableId + "` was too large (more than 10MB), sending two requests " +
-                "with `" + rows.size() + "`");
+        logger.warn("Request to `" + tableId + "` was too large (more than 10MB) with `" + rows.size() + "`, " +
+                "sending two requests with half of rows");
         this.performWriteRequest(tableId, collect.get(false));
         this.performWriteRequest(tableId, collect.get(true));
       } else {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -110,9 +110,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
         if (rows.size() == 1) {
           throw new ConnectException("One single row exceeded the Request Max Size for table `" + tableId + "`", exception);
         }
-
         Map<Boolean, SortedMap<SinkRecord, InsertAllRequest.RowToInsert>> collect = splitRowsInTwo(rows);
-
         logger.warn("Request to `" + tableId + "` was too large (more than 10MB) with `" + rows.size() + "`, " +
                 "sending two requests with half of rows");
         this.performWriteRequest(tableId, collect.get(false));


### PR DESCRIPTION
We cannot always know the size distribution of rows (especially if there are large JSON), hence a more dynamic way can offer a good trade-off between finding the perfect performance config, and avoid getting the connector stuck forever
