### PR TITLE
Fix MERGE query for tables with columns that have the same name of the table

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -48,6 +48,7 @@ public class MergeQueries {
   public static final String INTERMEDIATE_TABLE_ITERATION_FIELD_NAME = "i";
   public static final String INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME = "partitionTime";
   public static final String INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD = "batchNumber";
+  public static final String DESTINATION_TABLE_ALIAS = "dstTableAlias";
 
   private static final Logger logger = LoggerFactory.getLogger(MergeQueries.class);
 
@@ -213,7 +214,7 @@ public class MergeQueries {
     final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
     final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
 
-    return "MERGE " + table(destinationTable) + " "
+    return "MERGE " + table(destinationTable) + " " + DESTINATION_TABLE_ALIAS + " "
         + "USING ("
           + "SELECT * FROM ("
             + "SELECT ARRAY_AGG("
@@ -224,9 +225,9 @@ public class MergeQueries {
             + "GROUP BY " + String.join(", ", keyFields)
           + ")"
         + ") "
-        + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
+        + "ON " + DESTINATION_TABLE_ALIAS + "." + keyFieldName + "=src." + key + " "
         + "WHEN MATCHED AND src." + value + " IS NOT NULL "
-          + "THEN UPDATE SET " + valueColumns.stream().map(col -> "`" + col + "`=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> DESTINATION_TABLE_ALIAS + ".`" + col + "`=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
         + "WHEN MATCHED AND src." + value + " IS NULL "
           + "THEN DELETE "
         + "WHEN NOT MATCHED AND src." + value + " IS NOT NULL "
@@ -280,7 +281,7 @@ public class MergeQueries {
     final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
     final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
 
-    return "MERGE " + table(destinationTable) + " "
+    return "MERGE " + table(destinationTable) + " " + DESTINATION_TABLE_ALIAS + " "
         + "USING ("
           + "SELECT * FROM ("
             + "SELECT ARRAY_AGG("
@@ -291,9 +292,9 @@ public class MergeQueries {
             + "GROUP BY " + String.join(", ", keyFields)
           + ")"
         + ") "
-        + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
+        + "ON " + DESTINATION_TABLE_ALIAS + "." + keyFieldName + "=src." + key + " "
         + "WHEN MATCHED "
-          + "THEN UPDATE SET " + valueColumns.stream().map(col -> "`" + col + "`=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> DESTINATION_TABLE_ALIAS + ".`" + col + "`=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
         + "WHEN NOT MATCHED "
           + "THEN INSERT (`"
             + keyFieldName + "`, "

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
@@ -116,14 +116,14 @@ public class MergeQueriesTest {
   @Test
   public void testUpsertQueryWithPartitionTime() {
     String expectedQuery =
-        "MERGE " + table(DESTINATION_TABLE) + " "
+        "MERGE " + table(DESTINATION_TABLE) + " dstTableAlias "
           + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
             + "FROM " + table(INTERMEDIATE_TABLE) + " x "
             + "WHERE batchNumber=" + BATCH_NUMBER + " "
             + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
-          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "ON dstTableAlias." + KEY + "=src.key "
           + "WHEN MATCHED "
-            + "THEN UPDATE SET `f1`=src.value.f1, `f2`=src.value.f2, `f3`=src.value.f3, `f4`=src.value.f4 "
+            + "THEN UPDATE SET dstTableAlias.`f1`=src.value.f1, dstTableAlias.`f2`=src.value.f2, dstTableAlias.`f3`=src.value.f3, dstTableAlias.`f4`=src.value.f4 "
           + "WHEN NOT MATCHED "
             + "THEN INSERT (`"
               + KEY + "`, "
@@ -142,14 +142,14 @@ public class MergeQueriesTest {
   @Test
   public void testUpsertQueryWithoutPartitionTime() {
     String expectedQuery =
-        "MERGE " + table(DESTINATION_TABLE) + " "
+        "MERGE " + table(DESTINATION_TABLE) + " dstTableAlias "
           + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
             + "FROM " + table(INTERMEDIATE_TABLE) + " x "
             + "WHERE batchNumber=" + BATCH_NUMBER + " "
             + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
-          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "ONdstTableAlias." + KEY + "=src.key "
           + "WHEN MATCHED "
-            + "THEN UPDATE SET `f1`=src.value.f1, `f2`=src.value.f2, `f3`=src.value.f3, `f4`=src.value.f4 "
+            + "THEN UPDATE SET dstTableAlias.`f1`=src.value.f1, dstTableAlias.`f2`=src.value.f2, dstTableAlias.`f3`=src.value.f3, dstTableAlias.`f4`=src.value.f4 "
           + "WHEN NOT MATCHED "
             + "THEN INSERT (`"
               + KEY + "`, "
@@ -248,14 +248,14 @@ public class MergeQueriesTest {
   @Test
   public void testUpsertDeleteQueryWithPartitionTime() {
     String expectedQuery =
-        "MERGE " + table(DESTINATION_TABLE) + " "
+        "MERGE " + table(DESTINATION_TABLE) + " dstTableAlias "
           + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
             + "FROM " + table(INTERMEDIATE_TABLE) + " x "
             + "WHERE batchNumber=" + BATCH_NUMBER + " "
             + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
-          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "ON dstTableAlias." + KEY + "=src.key "
           + "WHEN MATCHED AND src.value IS NOT NULL "
-            + "THEN UPDATE SET `f1`=src.value.f1, `f2`=src.value.f2, `f3`=src.value.f3, `f4`=src.value.f4 "
+            + "THEN UPDATE SET dstTableAlias.`f1`=src.value.f1, dstTableAlias.`f2`=src.value.f2, dstTableAlias.`f3`=src.value.f3, dstTableAlias.`f4`=src.value.f4 "
           + "WHEN MATCHED AND src.value IS NULL "
             + "THEN DELETE "
           + "WHEN NOT MATCHED AND src.value IS NOT NULL "
@@ -276,14 +276,14 @@ public class MergeQueriesTest {
   @Test
   public void testUpsertDeleteQueryWithoutPartitionTime() {
     String expectedQuery =
-        "MERGE " + table(DESTINATION_TABLE) + " "
+        "MERGE " + table(DESTINATION_TABLE) + " dstTableAlias "
           + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
             + "FROM " + table(INTERMEDIATE_TABLE) + " x "
             + "WHERE batchNumber=" + BATCH_NUMBER + " "
             + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
-          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "ON dstTableAlias." + KEY + "=src.key "
           + "WHEN MATCHED AND src.value IS NOT NULL "
-            + "THEN UPDATE SET `f1`=src.value.f1, `f2`=src.value.f2, `f3`=src.value.f3, `f4`=src.value.f4 "
+            + "THEN UPDATE SET dstTableAlias.`f1`=src.value.f1, dstTableAlias.`f2`=src.value.f2, dstTableAlias.`f3`=src.value.f3, dstTableAlias.`f4`=src.value.f4 "
           + "WHEN MATCHED AND src.value IS NULL "
             + "THEN DELETE "
           + "WHEN NOT MATCHED AND src.value IS NOT NULL "


### PR DESCRIPTION
Adding table in queries to avoid exception such as "UPDATE ... SET does not support updating the entire row at [11:7]"

This happens when the table name and a column name have the same name