### PR TITLE
CCDB-4929: Adding error messages for union operation failure cases.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -396,8 +396,10 @@ public class SchemaManager {
       }
     }
 
-    checkState(firstField.getName().equals(secondField.getName()));
-    checkState(firstField.getType() == secondField.getType());
+    checkState(firstField.getName().equals(secondField.getName()),
+            "Cannot perform union operation on two fields having different names");
+    checkState(firstField.getType() == secondField.getType(),
+            "Cannot perform union operation on two fields having different datatypes");
 
     Field.Builder retBuilder = firstField.toBuilder();
     if (isFieldRelaxation(firstField, secondField)) {


### PR DESCRIPTION
CCDB-4929: Adding error messages for union operation failure cases.

This issue was seen a bunch of times during on-call and because there was no error message available rather just based on stack trace we couldn't classify these errors previously.