### PR TITLE
feature: simple protoype for using new BigQuery Storage Write API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-server:7.2.0
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.2.0
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - broker
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081

--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -38,6 +38,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquerystorage</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20220320</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
         </dependency>

--- a/kcbq-connector/quickstart/properties/log4j.properties
+++ b/kcbq-connector/quickstart/properties/log4j.properties
@@ -1,0 +1,18 @@
+# Set root logger level to DEBUG and its only appender to FooBar.
+log4j.rootLogger=DEBUG, FooBar
+
+# FooBar is set to be a ConsoleAppender.
+log4j.appender.FooBar=org.apache.log4j.ConsoleAppender
+
+# FooBar uses PatternLayout.
+log4j.appender.FooBar.layout=org.apache.log4j.PatternLayout
+#log4j.appender.FooBar.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.appender.FooBar.layout.ConversionPattern=%t %-5p %c %x - %m%n
+
+## suppress noisy logs from dependencies
+log4j.logger.org.reflections=ERROR
+log4j.logger.org.eclipse.jetty=ERROR
+log4j.logger.kafka=ERROR
+log4j.logger.org.apache.kafka=ERROR
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.io.grpc.netty=ERROR

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -46,6 +46,7 @@ import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
+import com.wepay.kafka.connect.bigquery.write.row.NeoStorageBigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryErrorResponses;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
@@ -245,6 +246,9 @@ public class BigQuerySinkTask extends SinkTask {
     Map<PartitionedTableId, TableWriterBuilder> tableWriterBuilders = new HashMap<>();
 
     for (SinkRecord record : records) {
+      logger.debug("get a sink record here");
+      logger.debug(record.value().toString());
+
       if (record.value() != null || config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)) {
         PartitionedTableId table = getRecordTable(record);
         if (!tableWriterBuilders.containsKey(table)) {
@@ -403,11 +407,9 @@ public class BigQuerySinkTask extends SinkTask {
                                             autoCreateTables,
                                             mergeBatches.intermediateToDestinationTables());
     } else if (autoCreateTables || allowNewBigQueryFields || allowRequiredFieldRelaxation) {
-      return new AdaptiveBigQueryWriter(bigQuery,
-                                        getSchemaManager(),
+      return new NeoStorageBigQueryWriter(bigQuery,
                                         retry,
-                                        retryWait,
-                                        autoCreateTables);
+                                        retryWait);
     } else {
       return new SimpleBigQueryWriter(bigQuery, retry, retryWait);
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BqToBqStorageSchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BqToBqStorageSchemaConverter.java
@@ -1,0 +1,72 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.storage.v1.TableFieldSchema;
+import com.google.cloud.bigquery.storage.v1.TableSchema;
+import com.google.common.collect.ImmutableMap;
+
+/** Converts structure from BigQuery client to BigQueryStorage client */
+public class BqToBqStorageSchemaConverter {
+  private static ImmutableMap<Field.Mode, TableFieldSchema.Mode> BQTableSchemaModeMap =
+      ImmutableMap.of(
+          Field.Mode.NULLABLE, TableFieldSchema.Mode.NULLABLE,
+          Field.Mode.REPEATED, TableFieldSchema.Mode.REPEATED,
+          Field.Mode.REQUIRED, TableFieldSchema.Mode.REQUIRED);
+
+  private static ImmutableMap<StandardSQLTypeName, TableFieldSchema.Type> BQTableSchemaTypeMap =
+      new ImmutableMap.Builder<StandardSQLTypeName, TableFieldSchema.Type>()
+          .put(StandardSQLTypeName.BOOL, TableFieldSchema.Type.BOOL)
+          .put(StandardSQLTypeName.BYTES, TableFieldSchema.Type.BYTES)
+          .put(StandardSQLTypeName.DATE, TableFieldSchema.Type.DATE)
+          .put(StandardSQLTypeName.DATETIME, TableFieldSchema.Type.DATETIME)
+          .put(StandardSQLTypeName.FLOAT64, TableFieldSchema.Type.DOUBLE)
+          .put(StandardSQLTypeName.GEOGRAPHY, TableFieldSchema.Type.GEOGRAPHY)
+          .put(StandardSQLTypeName.INT64, TableFieldSchema.Type.INT64)
+          .put(StandardSQLTypeName.NUMERIC, TableFieldSchema.Type.NUMERIC)
+          .put(StandardSQLTypeName.STRING, TableFieldSchema.Type.STRING)
+          .put(StandardSQLTypeName.STRUCT, TableFieldSchema.Type.STRUCT)
+          .put(StandardSQLTypeName.TIME, TableFieldSchema.Type.TIME)
+          .put(StandardSQLTypeName.TIMESTAMP, TableFieldSchema.Type.TIMESTAMP)
+          .build();
+
+  /**
+   * Converts from BigQuery client Table Schema to bigquery storage API Table Schema.
+   *
+   * @param schema the BigQuery client Table Schema
+   * @return the bigquery storage API Table Schema
+   */
+  public static TableSchema convertTableSchema(Schema schema) {
+    TableSchema.Builder result = TableSchema.newBuilder();
+    for (int i = 0; i < schema.getFields().size(); i++) {
+      result.addFields(i, convertFieldSchema(schema.getFields().get(i)));
+    }
+    return result.build();
+  }
+
+  /**
+   * Converts from bigquery v2 Field Schema to bigquery storage API Field Schema.
+   *
+   * @param field the BigQuery client Field Schema
+   * @return the bigquery storage API Field Schema
+   */
+  public static TableFieldSchema convertFieldSchema(Field field) {
+    TableFieldSchema.Builder result = TableFieldSchema.newBuilder();
+    if (field.getMode() == null) {
+      field = field.toBuilder().setMode(Field.Mode.NULLABLE).build();
+    }
+    result.setMode(BQTableSchemaModeMap.get(field.getMode()));
+    result.setName(field.getName());
+    result.setType(BQTableSchemaTypeMap.get(field.getType().getStandardType()));
+    if (field.getDescription() != null) {
+      result.setDescription(field.getDescription());
+    }
+    if (field.getSubFields() != null) {
+      for (int i = 0; i < field.getSubFields().size(); i++) {
+        result.addFields(i, convertFieldSchema(field.getSubFields().get(i)));
+      }
+    }
+    return result.build();
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/NeoStorageBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/NeoStorageBigQueryWriter.java
@@ -1,0 +1,46 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+import com.google.cloud.bigquery.*;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
+public class NeoStorageBigQueryWriter extends BigQueryWriter {
+  private static final Logger logger = LoggerFactory.getLogger(NeoStorageBigQueryWriter.class);
+
+  private final BigQuery bigQuery;
+
+  public NeoStorageBigQueryWriter(BigQuery bigQuery, int retry, long retryWait) {
+    super(retry, retryWait);
+    this.bigQuery = bigQuery;
+  }
+
+  @Override
+  public Map<Long, List<BigQueryError>> performWriteRequest(
+      PartitionedTableId tableId, SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows) {
+    InsertAllRequest request = createInsertAllRequest(tableId, rows.values());
+
+    logger.debug("RowToInsert");
+    JSONArray arr = new JSONArray();
+    for (InsertAllRequest.RowToInsert row : request.getRows()) {
+      JSONObject obj = new JSONObject(row.getContent());
+      arr.put(obj);
+      logger.debug(obj.toString());
+    }
+
+    try {
+      WriteToDefaultStream.writeToDefaultStream("", "", "", arr);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return new HashMap<>();
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/WriteToDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/WriteToDefaultStream.java
@@ -1,0 +1,170 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.storage.v1.*;
+import com.google.cloud.bigquery.storage.v1.Exceptions.StorageException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+import java.io.IOException;
+import java.util.concurrent.Phaser;
+
+public class WriteToDefaultStream {
+
+  private static final Logger logger = LoggerFactory.getLogger(WriteToDefaultStream.class);
+
+
+  public static void writeToDefaultStream(
+      String projectId, String datasetName, String tableName, JSONArray jsonArr)
+      throws DescriptorValidationException, InterruptedException, IOException {
+
+    TableName parentTable = TableName.of(projectId, datasetName, tableName);
+
+    DataWriter writer = new DataWriter();
+    writer.initialize(parentTable);
+
+    writer.append(new AppendContext(jsonArr, 0));
+
+    // Final cleanup for the stream during worker teardown.
+    writer.cleanup();
+    System.out.println("Appended records successfully.");
+  }
+
+  private static class AppendContext {
+
+    JSONArray data;
+    int retryCount = 0;
+
+    AppendContext(JSONArray data, int retryCount) {
+      this.data = data;
+      this.retryCount = retryCount;
+    }
+  }
+
+  private static class DataWriter {
+
+    private static final int MAX_RETRY_COUNT = 2;
+    private static final ImmutableList<Code> RETRIABLE_ERROR_CODES =
+        ImmutableList.of(Code.INTERNAL, Code.ABORTED, Code.CANCELLED);
+
+    // Track the number of in-flight requests to wait for all responses before shutting down.
+    private final Phaser inflightRequestCount = new Phaser(1);
+    private final Object lock = new Object();
+    private JsonStreamWriter streamWriter;
+
+
+
+    @GuardedBy("lock")
+    private RuntimeException error = null;
+
+    public void initialize(TableName parentTable)
+        throws DescriptorValidationException, IOException, InterruptedException {
+      BigQuery bigquery = BigQueryOptions.newBuilder().build().getService();
+      Table table = bigquery.getTable(parentTable.getDataset(), parentTable.getTable());
+      Schema schema = table.getDefinition().getSchema();
+      logger.debug(">>> bigqueryoptions debug");
+      logger.debug(schema.toString());
+
+      TableSchema tableSchema = BqToBqStorageSchemaConverter.convertTableSchema(schema);
+      streamWriter = JsonStreamWriter.newBuilder(parentTable.toString(), tableSchema).build();
+    }
+
+    public void append(AppendContext appendContext)
+        throws DescriptorValidationException, IOException {
+      synchronized (this.lock) {
+        // If earlier appends have failed, we need to reset before continuing.
+        if (this.error != null) {
+          throw this.error;
+        }
+      }
+      // Append asynchronously for increased throughput.
+      ApiFuture<AppendRowsResponse> future = streamWriter.append(appendContext.data);
+      ApiFutures.addCallback(
+          future, new AppendCompleteCallback(this, appendContext), MoreExecutors.directExecutor());
+
+      // Increase the count of in-flight requests.
+      inflightRequestCount.register();
+    }
+
+    public void cleanup() {
+      // Wait for all in-flight requests to complete.
+      inflightRequestCount.arriveAndAwaitAdvance();
+
+      // Close the connection to the server.
+      streamWriter.close();
+
+      // Verify that no error occurred in the stream.
+      synchronized (this.lock) {
+        if (this.error != null) {
+          throw this.error;
+        }
+      }
+    }
+
+    static class AppendCompleteCallback implements ApiFutureCallback<AppendRowsResponse> {
+
+      private final DataWriter parent;
+      private final AppendContext appendContext;
+
+      public AppendCompleteCallback(DataWriter parent, AppendContext appendContext) {
+        this.parent = parent;
+        this.appendContext = appendContext;
+      }
+
+      public void onSuccess(AppendRowsResponse response) {
+        logger.debug("Append success");
+        done();
+      }
+
+      public void onFailure(Throwable throwable) {
+        // If the wrapped exception is a StatusRuntimeException, check the state of the operation.
+        // If the state is INTERNAL, CANCELLED, or ABORTED, you can retry. For more information,
+        // see: https://grpc.github.io/grpc-java/javadoc/io/grpc/StatusRuntimeException.html
+        Status status = Status.fromThrowable(throwable);
+        if (appendContext.retryCount < MAX_RETRY_COUNT
+            && RETRIABLE_ERROR_CODES.contains(status.getCode())) {
+          appendContext.retryCount++;
+          try {
+            // Since default stream appends are not ordered, we can simply retry the appends.
+            // Retrying with exclusive streams requires more careful consideration.
+            this.parent.append(appendContext);
+            // Mark the existing attempt as done since it's being retried.
+            done();
+            return;
+          } catch (Exception e) {
+            // Fall through to return error.
+            System.out.format("Failed to retry append: %s\n", e);
+          }
+        }
+
+        synchronized (this.parent.lock) {
+          if (this.parent.error == null) {
+            StorageException storageException = Exceptions.toStorageException(throwable);
+            this.parent.error =
+                (storageException != null) ? storageException : new RuntimeException(throwable);
+          }
+        }
+        System.out.format("Error: %s\n", throwable);
+        done();
+      }
+
+      private void done() {
+        // Reduce the count of in-flight requests.
+        this.parent.inflightRequestCount.arriveAndDeregister();
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
 
         <confluent.version>5.5.1</confluent.version>
         <debezium.version>0.6.1</debezium.version>
-        <google.auth.version>0.21.1</google.auth.version>
+
+        <google.auth.version>0.27.0</google.auth.version>
         <google.cloud.version>1.119.0</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <jackson.version>2.10.2</jackson.version>


### PR DESCRIPTION
# What's this change 

Using new [Storage Write API](https://cloud.google.com/bigquery/docs/write-api#default_stream) instead of `insertAll` for streaming data into BigQuery.

This PR is just a simple prototype. Because:
* Using a workaround JsonStreamWriter instead of writing a whole new RecordConverter
* Messy code
* TBA

# How it tested

...