### PR TITLE
CCDB-5048: Adding topic2table map config support to BQ sink connector

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -54,6 +54,7 @@ import com.wepay.kafka.connect.bigquery.write.row.UpsertDeleteBigQueryWriter;
 import java.io.IOException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -63,13 +64,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -77,6 +72,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.TOPIC2TABLE_MAP_CONFIG;
 import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.intTable;
 
 /**
@@ -115,6 +111,7 @@ public class BigQuerySinkTask extends SinkTask {
   private ScheduledExecutorService loadExecutor;
 
   private Map<TableId, Table> cache;
+  private Map<String, String> topic2TableMap;
 
   /**
    * Create a new BigquerySinkTask.
@@ -183,25 +180,42 @@ public class BigQuerySinkTask extends SinkTask {
   private PartitionedTableId getRecordTable(SinkRecord record) {
     String tableName;
     String dataset = config.getString(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG);
-    String[] smtReplacement = record.topic().split(":");
-
-    if (smtReplacement.length == 2) {
-      dataset = smtReplacement[0];
-      tableName = smtReplacement[1];
-    } else if (smtReplacement.length == 1) {
-      tableName = smtReplacement[0];
+    if (topic2TableMap != null) {
+      // TODO what if the map doesn't contain the topic name?
+      // We don't need an explicit call to sanitize here because if the
+      // sanitize flag is true, then the topic2TableMap would already contain
+      // sanitized table names.
+      tableName = topic2TableMap.get(record.topic());
     } else {
-      throw new ConnectException(String.format(
-          "Incorrect regex replacement format in topic name '%s'. "
-              + "SMT replacement should either produce the <dataset>:<tableName> format " 
-              + "or just the <tableName> format.",
-          record.topic()
-      ));
+      String[] smtReplacement = record.topic().split(":");
+
+      if (smtReplacement.length == 2) {
+        dataset = smtReplacement[0];
+        tableName = smtReplacement[1];
+      } else if (smtReplacement.length == 1) {
+        tableName = smtReplacement[0];
+      } else {
+        throw new ConnectException(String.format(
+                "Incorrect regex replacement format in topic name '%s'. "
+                        + "SMT replacement should either produce the <dataset>:<tableName> format "
+                        + "or just the <tableName> format.",
+                record.topic()
+        ));
+      }
+      if (sanitize) {
+        tableName = FieldNameSanitizer.sanitizeName(tableName);
+      }
     }
 
-    if (sanitize) {
-      tableName = FieldNameSanitizer.sanitizeName(tableName);
-    }
+    // TODO: Order of execution of topic/table name modifications =>
+    // regex router SMT modifies topic name in sinkrecord.
+    // It could be either : separated or not.
+
+    // should we use topic2table map with sanitize table name? doesn't make sense.
+
+    // we use table name from above to sanitize table name further.
+
+
     TableId baseTableId = TableId.of(dataset, tableName);
     if (upsertDelete) {
       TableId intermediateTableId = mergeBatches.intermediateTableFor(baseTableId);
@@ -492,6 +506,7 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     recordConverter = getConverter(config);
+    topic2TableMap = parseTopic2TableMapConfig(config.getString(TOPIC2TABLE_MAP_CONFIG));
   }
 
   private void startGCSToBQLoadTask() {
@@ -520,6 +535,69 @@ public class BigQuerySinkTask extends SinkTask {
     int intervalSec = config.getInt(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG);
     loadExecutor.scheduleAtFixedRate(loadRunnable, intervalSec, intervalSec, TimeUnit.SECONDS);
   }
+
+  private Map<String, String> parseTopic2TableMapConfig(String topic2TableMapString) {
+    if (topic2TableMapString.isEmpty()) {
+      return null;
+    }
+
+    Map<String, String> topic2TableMap = new HashMap<>();
+
+    for (String str : topic2TableMapString.split(",")) {
+      String[] tt = str.split(":");
+
+      if (tt.length != 2) {
+        throw new ConfigException(
+                TOPIC2TABLE_MAP_CONFIG,
+                topic2TableMapString,
+                "One of the topic to table mappings has an invalid format."
+        );
+      }
+
+      String topic = tt[0].trim();
+      String table = tt[1].trim();
+
+      if (topic.isEmpty() || table.isEmpty()) {
+        throw new ConfigException(
+                TOPIC2TABLE_MAP_CONFIG,
+                topic2TableMapString,
+                "One of the topic to table mappings has an invalid format."
+        );
+      }
+
+      if (topic2TableMap.containsKey(topic)) {
+        throw new ConfigException(
+                TOPIC2TABLE_MAP_CONFIG,
+                topic2TableMapString,
+                String.format(
+                        "The topic name %s is duplicated. Topic names cannot be duplicated.",
+                        topic
+                )
+        );
+      }
+
+      if (topic2TableMap.containsValue(table)) {
+        throw new ConfigException(
+                TOPIC2TABLE_MAP_CONFIG,
+                topic2TableMapString,
+                String.format(
+                        "The table name %s is duplicated. Table names cannot be duplicated.",
+                        table
+                )
+        );
+      }
+      if (sanitize) {
+        table = FieldNameSanitizer.sanitizeName(table);
+      }
+      topic2TableMap.put(topic, table);
+    }
+
+    if (topic2TableMap.isEmpty()) {
+      return null;
+    }
+    return topic2TableMap;
+  }
+
 
   private void maybeStartMergeFlushTask() {
     long intervalMs = config.getLong(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -181,11 +181,7 @@ public class BigQuerySinkTask extends SinkTask {
     String tableName;
     String dataset = config.getString(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG);
     if (topic2TableMap != null) {
-      // TODO what if the map doesn't contain the topic name?
-      // We don't need an explicit call to sanitize here because if the
-      // sanitize flag is true, then the topic2TableMap would already contain
-      // sanitized table names.
-      tableName = topic2TableMap.get(record.topic());
+      tableName = topic2TableMap.getOrDefault(record.topic(), record.topic());
     } else {
       String[] smtReplacement = record.topic().split(":");
 
@@ -535,22 +531,6 @@ public class BigQuerySinkTask extends SinkTask {
     int intervalSec = config.getInt(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG);
     loadExecutor.scheduleAtFixedRate(loadRunnable, intervalSec, intervalSec, TimeUnit.SECONDS);
   }
-
-  private Map<String, String> parseTopic2TableMapConfig(String topic2TableMapString) {
-    if (topic2TableMapString.isEmpty()) {
-      return null;
-    }
-    Map<String, String> topic2TableMap = new HashMap<>();
-    // It's already validated, so we can just populate the map
-    for (String str : topic2TableMapString.split(",")) {
-      String[] tt = str.split(":");
-      String topic = tt[0].trim();
-      String table = tt[1].trim();
-      topic2TableMap.put(topic, sanitize ? FieldNameSanitizer.sanitizeName(table) : table);
-    }
-    return topic2TableMap;
-  }
-
 
   private void maybeStartMergeFlushTask() {
     long intervalMs = config.getLong(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -506,7 +506,7 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     recordConverter = getConverter(config);
-    topic2TableMap = config.getTopic2TableMap(sanitize).orElse(null);
+    topic2TableMap = config.getTopic2TableMap().orElse(null);
   }
 
   private void startGCSToBQLoadTask() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -162,6 +162,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "Whether to automatically sanitize topic names before using them as table names;"
       + " if not enabled topic names will be used directly as table names";
 
+  public static final String TOPIC2TABLE_MAP_CONFIG =                     "topic2TableMap";
+  private static final ConfigDef.Type TOPIC2TABLE_MAP_TYPE =              ConfigDef.Type.STRING;
+  public static final String TOPIC2TABLE_MAP_DEFAULT = "";
+  private static final ConfigDef.Importance TOPIC2TABLE_MAP_IMPORTANCE =  ConfigDef.Importance.LOW;
+  public static final String TOPIC2TABLE_MAP_DOC = "Map of topics to tables (optional). "
+          + "Format: comma-separated tuples, e.g. <topic-1>:<table-1>,<topic-2>:<table-2>,... " +
+          "Note that topic name should not be modified using regex SMT if using this option.";
+
   public static final String SANITIZE_FIELD_NAME_CONFIG =                     "sanitizeFieldNames";
   private static final ConfigDef.Type SANITIZE_FIELD_NAME_TYPE =              ConfigDef.Type.BOOLEAN;
   public static final Boolean SANITIZE_FIELD_NAME_DEFAULT =                   false;
@@ -555,6 +563,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             SANITIZE_TOPICS_IMPORTANCE,
             SANITIZE_TOPICS_DOC
         ).define(
+            TOPIC2TABLE_MAP_CONFIG,
+            TOPIC2TABLE_MAP_TYPE,
+            TOPIC2TABLE_MAP_DEFAULT,
+            TOPIC2TABLE_MAP_IMPORTANCE,
+            TOPIC2TABLE_MAP_DOC
+          ).define(
             SANITIZE_FIELD_NAME_CONFIG,
             SANITIZE_FIELD_NAME_TYPE,
             SANITIZE_FIELD_NAME_DEFAULT,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -166,8 +166,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String TOPIC2TABLE_MAP_DOC = "Map of topics to tables (optional). "
           + "Format: comma-separated tuples, e.g. <topic-1>:<table-1>,<topic-2>:<table-2>,... " +
           "Note that topic name should not be modified using regex SMT while using this option." +
-          "Also note that if sanitizeTopics is true, then the table names supplied in this config " +
-          "would be sanitized according to the same rules";
+          "Also note that SANITIZE_TOPICS_CONFIG would be ignored if this config is set.";
   private static final ConfigDef.Validator TOPIC2TABLE_MAP_VALIDATOR = (name, value) -> {
     String topic2TableMapString = (String) ConfigDef.parseType(name, value, TOPIC2TABLE_MAP_TYPE);
 
@@ -1010,8 +1009,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return parseTimePartitioningType(getString(TIME_PARTITIONING_TYPE_CONFIG));
   }
 
-  public Optional<Map<String, String>> getTopic2TableMap(boolean sanitize) {
-    return Optional.ofNullable(parseTopic2TableMapConfig(getString(TOPIC2TABLE_MAP_CONFIG), sanitize));
+  public Optional<Map<String, String>> getTopic2TableMap() {
+    return Optional.ofNullable(parseTopic2TableMapConfig(getString(TOPIC2TABLE_MAP_CONFIG)));
   }
 
   private Optional<TimePartitioning.Type> parseTimePartitioningType(String rawPartitioningType) {
@@ -1035,7 +1034,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
     }
   }
 
-  private Map<String, String> parseTopic2TableMapConfig(String topic2TableMapString, boolean sanitize) {
+  private Map<String, String> parseTopic2TableMapConfig(String topic2TableMapString) {
     if (topic2TableMapString.isEmpty()) {
       return null;
     }
@@ -1045,7 +1044,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
       String[] tt = str.split(":");
       String topic = tt[0].trim();
       String table = tt[1].trim();
-      topic2TableMap.put(topic, sanitize ? FieldNameSanitizer.sanitizeName(table) : table);
+      topic2TableMap.put(topic, table);
     }
     return topic2TableMap.isEmpty() ? null : topic2TableMap;
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -166,7 +166,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String TOPIC2TABLE_MAP_DOC = "Map of topics to tables (optional). "
           + "Format: comma-separated tuples, e.g. <topic-1>:<table-1>,<topic-2>:<table-2>,... " +
           "Note that topic name should not be modified using regex SMT while using this option." +
-          "Also note that SANITIZE_TOPICS_CONFIG would be ignored if this config is set.";
+          "Also note that SANITIZE_TOPICS_CONFIG would be ignored if this config is set." +
+          "Lastly, if the topic2table map doesn't contain the topic for a record, a table" +
+          " with the same name as the topic name would be created";
   private static final ConfigDef.Validator TOPIC2TABLE_MAP_VALIDATOR = (name, value) -> {
     String topic2TableMapString = (String) ConfigDef.parseType(name, value, TOPIC2TABLE_MAP_TYPE);
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -265,7 +265,7 @@ public class BigQuerySinkConfigTest {
     Map<String, String> topic2TableMap = new HashMap<>();
     topic2TableMap.put("topic", "table");
     topic2TableMap.put("topic2", "table2");
-    assertEquals(topic2TableMap, config.getTopic2TableMap(config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG)).get());
+    assertEquals(topic2TableMap, config.getTopic2TableMap().get());
   }
 
   @Test
@@ -273,7 +273,7 @@ public class BigQuerySinkConfigTest {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.TOPIC2TABLE_MAP_CONFIG, "");
     BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
-    assertFalse(config.getTopic2TableMap(config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG)).isPresent());
+    assertFalse(config.getTopic2TableMap().isPresent());
   }
 
   @Test
@@ -281,19 +281,7 @@ public class BigQuerySinkConfigTest {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.TOPIC2TABLE_MAP_CONFIG, ",");
     BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
-    assertFalse(config.getTopic2TableMap(config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG)).isPresent());
-  }
-
-  @Test
-  public void testTopicNameShouldGetSanitizedIfSanitizeFlagTrue() {
-    Map<String, String> configProperties = propertiesFactory.getProperties();
-    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-    configProperties.put(BigQuerySinkConfig.TOPIC2TABLE_MAP_CONFIG, "topic:table#badname, topic2:2table2");
-    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
-    Map<String, String> topic2TableMap = new HashMap<>();
-    topic2TableMap.put("topic", "table_badname");
-    topic2TableMap.put("topic2", "_2table2");
-    assertEquals(topic2TableMap, config.getTopic2TableMap(config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG)).get());
+    assertFalse(config.getTopic2TableMap().isPresent());
   }
 
 }


### PR DESCRIPTION
Adding topic2table map config support to BQ sink connector. This way users can directly configure what table should records from a given topic be ingested into. I have tested on docker playground the following scenarios =>

1) sanitizeTopic flag is ignored when topic2TableMap is supplied. So, whatever table name is specified in the map would be used as is.
2) If the topic name in the record is not in the topic2TableMap, then the topic name would be used as the table name. 