### PR TITLE
CCDB-5226 Adding more uniqueness to GCS blob object filename 

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -251,7 +251,8 @@ public class BigQuerySinkTask extends SinkTask {
           TableWriterBuilder tableWriterBuilder;
           if (config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String topic = record.topic();
-            String gcsBlobName = topic + "_" + uuid + "_" + Instant.now().toEpochMilli();
+            long offset = record.kafkaOffset();
+            String gcsBlobName = topic + "_" + uuid + "_" + Instant.now().toEpochMilli() + "_" + offset;
             String gcsFolderName = config.getString(BigQuerySinkConfig.GCS_FOLDER_NAME_CONFIG);
             if (gcsFolderName != null && !"".equals(gcsFolderName)) {
               gcsBlobName = gcsFolderName + "/" + gcsBlobName;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -42,6 +42,7 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
@@ -75,6 +76,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class BigQuerySinkTaskTest {
   private static SinkTaskPropertiesFactory propertiesFactory;
@@ -130,6 +133,44 @@ public class BigQuerySinkTaskTest {
     verify(bigQuery, times(1)).insertAll(any(InsertAllRequest.class));
   }
 
+  @Test
+  public void testPutForGCSToBQ() {
+    final String topic = "test-topic";
+    final int repeats = 20;
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+    properties.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, "test-topic");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any())).thenReturn(mockTable);
+
+    Storage storage = mock(Storage.class);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+
+    when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Map<TableId, Table> cache = new HashMap<>();
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    IntStream.range(0,repeats).forEach(i -> testTask.put(Collections.singletonList(spoofSinkRecord(topic))));
+
+    ArgumentCaptor<BlobInfo> blobInfo = ArgumentCaptor.forClass(BlobInfo.class);
+    testTask.flush(Collections.emptyMap());
+
+    verify(storage, times(repeats)).create(blobInfo.capture(), (byte[])anyObject());
+    assertEquals(repeats, blobInfo.getAllValues().stream().map(info -> info.getBlobId().getName()).collect(Collectors.toSet()).size());
+
+  }
   @Test
   public void testSimplePutWhenSchemaRetrieverIsNotNull() {
     final String topic = "test-topic";

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <java.version>8</java.version>
 
         <confluent.version>5.5.1</confluent.version>
-        <debezium.version>0.6.1</debezium.version>
+        <debezium.version>0.6.2</debezium.version>
         <google.auth.version>0.21.1</google.auth.version>
         <google.cloud.version>1.119.0</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>


### PR DESCRIPTION
This PR adds more uniqueness to generates GCS filename by appending _[OFFSET] at the end as kafka record offsets are unique. 
This change is needed as we receive 'Missing record' issue from customers for BigQuery Batch mode. After overriding record consumption property `consumer.override.max.poll.records=1` by 1 and keeping rest of the code same, we could locally observe lesser number of records in BQ table. This happens as multiple files with same name get generated by a task in 1 millisecond and GCS only keeps 1 file with a unique name as live version (others are marked as non-live versions).
<img width="1189" alt="Screenshot 2022-12-09 at 5 24 00 PM" src="https://user-images.githubusercontent.com/117655560/206894242-fc5befae-5d38-4a4c-8066-3430fcb2e1e2.png">


This is hard to reproduce with default poll count of 500 (we could not reproduce the issue after multiple re-tries with 500 poll rate).
Appending offset (which is different for each record) makes sure the filenames, even if generated within same 1 millisecond , are unique.
Test results with 21 records
<img width="1704" alt="Screenshot 2022-12-09 at 5 25 06 PM" src="https://user-images.githubusercontent.com/117655560/206894300-4e9ed59a-5ed7-45e5-90f4-1aa0457531eb.png">
<img width="1704" alt="Screenshot 2022-12-09 at 5 25 37 PM" src="https://user-images.githubusercontent.com/117655560/206894264-7ba0ea7f-a6a4-4f8c-82f0-36168a572602.png">
<img width="695" alt="Screenshot 2022-12-09 at 5 26 58 PM" src="https://user-images.githubusercontent.com/117655560/206894307-ea2ee80d-3067-4fa4-819c-7978a3139113.png">