### PR TITLE
Ccdb 5286 fix empty batches creation

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -109,6 +109,10 @@ public class MergeQueries {
   }
 
   public void mergeFlush(TableId intermediateTable) {
+    if(mergeBatches.isCurrentBatchEmpty(intermediateTable)){
+      logger.debug("Merge flush is not performed as the current batch is empty.");
+      return;
+    }
     final TableId destinationTable = mergeBatches.destinationTableFor(intermediateTable);
     final int batchNumber = mergeBatches.incrementBatch(intermediateTable);
     logger.trace("Triggering merge flush from {} to {} for batch {}",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -191,6 +191,20 @@ public class MergeBatches {
   }
 
   /**
+   * Checks if current batch of intermediate table has no records so far
+   * @param intermediateTable the table whose current batch needs to be checked
+   * @return true if no records, else false
+   */
+  public boolean isCurrentBatchEmpty(TableId intermediateTable) {
+    Batch currentBatch;
+    AtomicInteger batchCount = batchNumbers.get(intermediateTable);
+    synchronized (batchCount) {
+      currentBatch = batch(intermediateTable, batchCount.get());
+    }
+    return currentBatch == null || currentBatch.total.get() == 0L;
+  }
+  
+  /**
    * Increment the batch number for the given table, and return the old batch number.
    * @param intermediateTable the table whose batch number should be incremented
    * @return the batch number for the table, pre-increment


### PR DESCRIPTION
The MergeFlush method in BQ SinkConnector for upsert/delete mode keeps increasing batch number even if the current batch has 0 records. This results in 
 - unnecessary resource consumption
 - unexpected behaviour as empty batches are also processed just like any other batch. 

This PR fixes empty batch creation by preventing batch creation when current is not initialised or there are no records in current batch.

Below recording shows the sequential completion of records 
https://user-images.githubusercontent.com/117655560/209628904-33863fa2-afad-4099-957a-d21b1a3037fc.mov

