### PR TITLE
CCDB-5287: updates documentation for configs, logs warning if mergeIntervalMs lower limit is not met

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -282,6 +282,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
       + "suffix.";
 
   public static final String MERGE_INTERVAL_MS_CONFIG =                    "mergeIntervalMs";
+  public static final String MERGE_RECORDS_THRESHOLD_CONFIG =                    "mergeRecordsThreshold";
   private static final ConfigDef.Type MERGE_INTERVAL_MS_TYPE =              ConfigDef.Type.LONG;
   public static final long MERGE_INTERVAL_MS_DEFAULT =                     60_000L;
   private static final ConfigDef.Validator MERGE_INTERVAL_MS_VALIDATOR =   ConfigDef.LambdaValidator.with(
@@ -301,10 +302,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
   );
   private static final ConfigDef.Importance MERGE_INTERVAL_MS_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String MERGE_INTERVAL_MS_DOC =
-      "How often (in milliseconds) to perform a merge flush, if upsert/delete is enabled. Can be "
-      + "set to -1 to disable periodic flushing.";
+      "How often (in milliseconds) to perform a merge flush, if upsert/delete is enabled. Can be set to -1" +
+              " to disable periodic flushing. If enabled should be set to at least 10 seconds(A validation" +
+              " would be introduced in future release to this effect). Either " +MERGE_INTERVAL_MS_CONFIG + " or "
+              + MERGE_RECORDS_THRESHOLD_CONFIG + " must be enabled.";
 
-  public static final String MERGE_RECORDS_THRESHOLD_CONFIG =                    "mergeRecordsThreshold";
   private static final ConfigDef.Type MERGE_RECORDS_THRESHOLD_TYPE =             ConfigDef.Type.LONG;
   public static final long MERGE_RECORDS_THRESHOLD_DEFAULT =                     -1;
   private static final ConfigDef.Validator MERGE_RECORDS_THRESHOLD_VALIDATOR =   ConfigDef.LambdaValidator.with(
@@ -325,7 +327,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance MERGE_RECORDS_THRESHOLD_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String MERGE_RECORDS_THRESHOLD_DOC =
       "How many records to write to an intermediate table before performing a merge flush, if " 
-      + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing.";
+      + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing. Either "
+              + MERGE_INTERVAL_MS_CONFIG + " or " + MERGE_RECORDS_THRESHOLD_CONFIG + " must be enabled.";
 
   public static final String THREAD_POOL_SIZE_CONFIG =                  "threadPoolSize";
   private static final ConfigDef.Type THREAD_POOL_SIZE_TYPE =           ConfigDef.Type.INT;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -303,9 +303,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance MERGE_INTERVAL_MS_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String MERGE_INTERVAL_MS_DOC =
       "How often (in milliseconds) to perform a merge flush, if upsert/delete is enabled. Can be set to -1" +
-              " to disable periodic flushing. If enabled should be set to at least 10 seconds(A validation" +
-              " would be introduced in future release to this effect). Either " +MERGE_INTERVAL_MS_CONFIG + " or "
-              + MERGE_RECORDS_THRESHOLD_CONFIG + " must be enabled.";
+              " to disable periodic flushing. Either " +MERGE_INTERVAL_MS_CONFIG + " or "
+              + MERGE_RECORDS_THRESHOLD_CONFIG + ", or both must be enabled.\nThis should not be set to less" +
+              " than 10 seconds. A validation would be introduced in a future release to this effect.";
 
   private static final ConfigDef.Type MERGE_RECORDS_THRESHOLD_TYPE =             ConfigDef.Type.LONG;
   public static final long MERGE_RECORDS_THRESHOLD_DEFAULT =                     -1;
@@ -328,7 +328,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String MERGE_RECORDS_THRESHOLD_DOC =
       "How many records to write to an intermediate table before performing a merge flush, if " 
       + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing. Either "
-              + MERGE_INTERVAL_MS_CONFIG + " or " + MERGE_RECORDS_THRESHOLD_CONFIG + " must be enabled.";
+              + MERGE_INTERVAL_MS_CONFIG + " or " + MERGE_RECORDS_THRESHOLD_CONFIG + ", or both must be enabled.";
 
   public static final String THREAD_POOL_SIZE_CONFIG =                  "threadPoolSize";
   private static final ConfigDef.Type THREAD_POOL_SIZE_TYPE =           ConfigDef.Type.INT;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
@@ -19,6 +19,9 @@
 
 package com.wepay.kafka.connect.bigquery.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +42,7 @@ public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQu
       MERGE_INTERVAL_MS_CONFIG, MERGE_RECORDS_THRESHOLD_CONFIG, KAFKA_KEY_FIELD_NAME_CONFIG
   ));
 
+  private static final Logger logger = LoggerFactory.getLogger(UpsertDeleteValidator.class);
   @Override
   protected Collection<String> dependents() {
     return DEPENDENTS;
@@ -58,6 +62,13 @@ public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQu
           "%s and %s cannot both be -1",
           MERGE_INTERVAL_MS_CONFIG,
           MERGE_RECORDS_THRESHOLD_CONFIG
+      ));
+    }
+
+    if (mergeInterval != -1 && mergeInterval < 10_000L) {
+      logger.warn(String.format(
+              "%s should be at least 10 seconds",
+              MERGE_INTERVAL_MS_CONFIG
       ));
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
@@ -67,7 +67,8 @@ public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQu
 
     if (mergeInterval != -1 && mergeInterval < 10_000L) {
       logger.warn(String.format(
-              "%s should be at least 10 seconds",
+              "%s should not be set to less than 10 seconds. A validation would be introduced in a future release to " +
+                      "this effect.",
               MERGE_INTERVAL_MS_CONFIG
       ));
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
@@ -43,6 +43,7 @@ public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQu
   ));
 
   private static final Logger logger = LoggerFactory.getLogger(UpsertDeleteValidator.class);
+
   @Override
   protected Collection<String> dependents() {
     return DEPENDENTS;


### PR DESCRIPTION
This PR does following -
1. Logs warning if mergeIntervalMs config is set to less than 10 sec. The corresponding validation is not added due to backward compatibility concerns. Read here to understand why we need a lower limit on this config. https://confluentinc.atlassian.net/browse/CCDB-5274?focusedCommentId=1279019
2. Updates documentation for point 1
3. Updates documentation for validation 1 mentioned in description https://confluentinc.atlassian.net/browse/CCDB-5287 

Updated documentation text and logged warning screenshots - 
<img width="671" alt="Screenshot 2022-12-28 at 11 18 13 AM" src="https://user-images.githubusercontent.com/117655560/209766300-34cc8e24-25be-4fe9-a18b-f5c677e7b87d.png">

<img width="1671" alt="Screenshot 2022-12-28 at 11 18 51 AM" src="https://user-images.githubusercontent.com/117655560/209766303-7aaf493c-3c5b-41ea-ae90-656f4b3c9e71.png">

<img width="671" alt="Screenshot 2022-12-28 at 11 17 48 AM" src="https://user-images.githubusercontent.com/117655560/209766294-140fcf80-1817-4dc5-a758-01cc86e1f509.png">
