### PR TITLE
[CCDB-5307] Upgrade protobuf-java to 3.19.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <google.auth.version>0.9.0</google.auth.version>
         <google.cloud.version>0.25.0-alpha</google.cloud.version>
         <google.http.version>1.22.0</google.http.version>
+        <google.protobuf.version>3.19.6</google.protobuf.version>
         <guava.version>20.0</guava.version>
         <jackson.version>2.6.3</jackson.version>
         <kafka.version>1.0.0</kafka.version>
@@ -222,6 +223,11 @@
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-jackson2</artifactId>
                 <version>${google.http.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${google.protobuf.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Problem

Vulnerable dependency "protobuf-java" for kafka-connect-bigquery
CVE: https://confluentinc.atlassian.net/browse/CCDB-5307

## Solution
Upgrading to 3.19.6 from 1.1.x onwards
Will do ping merge after PR merge

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
`mvn dependency:tree` output

<img width="584" alt="Screenshot 2023-01-11 at 11 34 27 AM" src="https://user-images.githubusercontent.com/121012039/211730738-f3ee7802-776f-4fa3-a001-d91a38a3ac27.png">

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests
    -  Tested the changes via kafka docker playground. Modified [this](https://github.com/vdesabou/kafka-docker-playground/blob/master/connect/connect-gcp-bigquery-sink/gcp-bigquery-sink.sh) script which generates data to send to kafka which is consumed by bigquery sink connector to send to BigQuery DW.
    -   <img width="840" alt="Screenshot 2023-01-13 at 7 14 56 PM" src="https://user-images.githubusercontent.com/121012039/212334933-453fc42a-7077-42db-bcb7-3e6b52150d44.png">

## Release
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
