### PR TITLE
Add logical converter for Debezium's JSON data type

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -21,6 +21,7 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
 import com.google.cloud.bigquery.LegacySQLTypeName;
 
+import io.debezium.data.Json;
 import io.debezium.time.Date;
 import io.debezium.time.MicroTime;
 import io.debezium.time.MicroTimestamp;
@@ -48,6 +49,7 @@ public class DebeziumLogicalConverters {
     LogicalConverterRegistry.register(Time.SCHEMA_NAME, new TimeConverter());
     LogicalConverterRegistry.register(ZonedTimestamp.SCHEMA_NAME, new ZonedTimestampConverter());
     LogicalConverterRegistry.register(Timestamp.SCHEMA_NAME, new TimestampConverter());
+    LogicalConverterRegistry.register(Json.LOGICAL_NAME, new JsonConverter());
   }
 
   private static final int MICROS_IN_SEC = 1000000;
@@ -200,6 +202,25 @@ public class DebeziumLogicalConverters {
               .append(DateTimeFormatter.ISO_TIME)
               .toFormatter();
       return bqZonedTimestampFormat.format(parsedTime);
+    }
+  }
+
+  /**
+   * Class for converting Debezium JSON data types to BigQuery JSON data types.
+   */
+  public static class JsonConverter extends LogicalTypeConverter {
+    /**
+     * Create a new ZoneTimestampConverter.
+     */
+    public JsonConverter() {
+      super(Json.LOGICAL_NAME,
+              Schema.Type.STRING,
+              LegacySQLTypeName.JSON);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      return (String) kafkaConnectObject;
     }
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -30,6 +30,7 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConve
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimeConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimestampConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.ZonedTimestampConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.JsonConverter;
 
 import org.apache.kafka.connect.data.Schema;
 
@@ -153,5 +154,18 @@ public class DebeziumLogicalConvertersTest {
 
     String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
     assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
+  }
+
+  @Test
+  public void testJsonConversion() {
+    JsonConverter converter = new JsonConverter();
+
+    assertEquals(LegacySQLTypeName.JSON, converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.STRING);
+    } catch (Exception ex) {
+      fail("Expected encoding type check to succeed.");
+    }
   }
 }


### PR DESCRIPTION
When working with Debezium's MongoDB connector, the primary top-level fields (before, after, patch, filter) are wrapped up in the `io.debezium.data.Json` type. Data serialized with this type is stored as legitimate JSON strings. BigQuery's Storage Write API expects this data to be in this format (https://cloud.google.com/bigquery/docs/write-api#data_type_conversions)

Nothing really needs to be done on the conversion side; the primary objective is to map the Debezium and BigQuery data types together to allow the connector to properly manage the BigQuery schema.