### PR TITLE
CC-18981: Add KIP-610 feature to send errant records to DLQ

### DIFF
--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -200,10 +200,10 @@
                             </tags>
 
                             <requirements>
-                                <requirement>Apache Kafka 0.11 or higher / Confluent Platform 3.3 or higher</requirement>
+                                <requirement>Apache Kafka 2.6 or higher / Confluent Platform 6.0 or higher</requirement>
                                 <requirement>Java 1.8 or higher</requirement>
                                 <requirement>Active Google Cloud Platform (GCP) account with authorization to create resources</requirement>
-                                <requirement>Kafka Connect 0.11 or higher / Confluent Platform 3.3 or higher</requirement>
+                                <requirement>Kafka Connect 2.6 or higher / Confluent Platform 6.0 or higher</requirement>
                             </requirements>
                         </configuration>
                     </execution>

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/ErrantRecordHandler.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/ErrantRecordHandler.java
@@ -1,0 +1,48 @@
+package com.wepay.kafka.connect.bigquery;
+
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class ErrantRecordHandler {
+    private static final Logger logger = LoggerFactory.getLogger(ErrantRecordHandler.class);
+    private final ErrantRecordReporter errantRecordReporter;
+
+    private static final List<String> allowedBigQueryErrorReason = Arrays.asList("invalid");
+
+    public ErrantRecordHandler(ErrantRecordReporter errantRecordReporter) {
+        this.errantRecordReporter = errantRecordReporter;
+    }
+
+    public void sendRecordsToDLQ(Set<SinkRecord> rows, Exception e) {
+        if(errantRecordReporter != null) {
+            for (SinkRecord r : rows) {
+                // Reporting records in async mode
+                errantRecordReporter.report(r, e);
+            }
+        } else {
+            logger.warn("Cannot send Records to DLQ as ErrantRecordReporter is null");
+        }
+    }
+
+    public ErrantRecordReporter getErrantRecordReporter() {
+        return errantRecordReporter;
+    }
+
+    public List<String> getAllowedBigQueryErrorReason() {
+        return allowedBigQueryErrorReason;
+    }
+
+    public boolean isErrorReasonAllowed(String errorReason) {
+        for (String allowedErrorReason: allowedBigQueryErrorReason) {
+            if (errorReason.equalsIgnoreCase(allowedErrorReason))
+                return true;
+        }
+        return false;
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 
@@ -63,13 +64,15 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
    * @param autoCreateTables Whether tables should be automatically created
+   * @param errantRecordHandler Used to handle errant records
    */
   public AdaptiveBigQueryWriter(BigQuery bigQuery,
                                 SchemaManager schemaManager,
                                 int retry,
                                 long retryWait,
-                                boolean autoCreateTables) {
-    super(retry, retryWait);
+                                boolean autoCreateTables,
+                                ErrantRecordHandler errantRecordHandler) {
+    super(retry, retryWait, errantRecordHandler);
     this.bigQuery = bigQuery;
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -22,10 +22,9 @@ package com.wepay.kafka.connect.bigquery.write.row;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest;
-
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
-
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +36,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A class for writing lists of rows to a BigQuery table.
@@ -51,17 +51,21 @@ public abstract class BigQueryWriter {
   private final long retryWaitMs;
   private final Random random;
 
+  private final ErrantRecordHandler errantRecordHandler;
+
   /**
    * @param retries the number of times to retry a request if BQ returns an internal service error
    *                or a service unavailable error.
    * @param retryWaitMs the amount of time to wait in between reattempting a request if BQ returns
    *                    an internal service error or a service unavailable error.
+   * @param errantRecordHandler Used to handle errant records
    */
-  public BigQueryWriter(int retries, long retryWaitMs) {
+  public BigQueryWriter(int retries, long retryWaitMs, ErrantRecordHandler errantRecordHandler) {
     this.retries = retries;
     this.retryWaitMs = retryWaitMs;
 
     this.random = new Random();
+    this.errantRecordHandler = errantRecordHandler;
   }
 
   /**
@@ -121,8 +125,23 @@ public abstract class BigQueryWriter {
           mostRecentException = new BigQueryConnectException(table.toString(), failedRowsMap);
           retryCount++;
         } else {
-          // throw an exception in case of complete failure
-          throw new BigQueryConnectException(table.toString(), failedRowsMap);
+          if (errantRecordHandler.getErrantRecordReporter() != null) {
+            failedRowsMap = filterAndSendRecordsToDLQ(rows, failedRowsMap, table);
+            if (failedRowsMap.isEmpty()) {
+              logger.info("Failed Row Map is empty");
+              return;
+            }
+            if (hasStoppedErrorRecords(failedRowsMap)) {
+                rows = getFailedRows(rows, failedRowsMap.keySet(), table);
+                mostRecentException = new BigQueryConnectException(table.toString(), failedRowsMap);
+                retryCount++;
+            } else {
+                throw new BigQueryConnectException(table.toString(), failedRowsMap);
+            }
+          } else {
+            // throw an exception in case of complete failure
+            throw new BigQueryConnectException(table.toString(), failedRowsMap);
+          }
         }
       } catch (BigQueryException err) {
         mostRecentException = err;
@@ -143,9 +162,14 @@ public abstract class BigQueryWriter {
         }
       }
     } while (retryCount <= retries);
-    throw new BigQueryConnectException(
-        String.format("Exceeded configured %d attempts for write request", retries),
-        mostRecentException);
+      if (errantRecordHandler.getErrantRecordReporter() != null && failedRowsMap!=null) {
+        failedRowsMap = filterAndSendRecordsToDLQ(rows, failedRowsMap, table);
+        if (failedRowsMap.isEmpty())
+            return;
+      }
+      throw new BigQueryConnectException(
+          String.format("Exceeded configured %d attempts for write request", retries),
+          mostRecentException);
   }
 
   /**
@@ -187,5 +211,57 @@ public abstract class BigQueryWriter {
   private void waitRandomTime() throws InterruptedException {
     // wait
     Thread.sleep(retryWaitMs + random.nextInt(WAIT_MAX_JITTER));
+  }
+
+  /**
+   * Filter and send Records to DLQ according to allowedBigQueryReason List
+   * @param rows The rows to write.
+   * @param failedRowsMap map from failed row id to the BigQueryError
+   * @param table The BigQuery table to write the rows to
+   * @return Filtered Map from failed row id to the BigQueryError which cannot be sent to DLQ
+   */
+  private Map<Long, List<BigQueryError>>  filterAndSendRecordsToDLQ(
+      SortedMap<SinkRecord,
+      InsertAllRequest.RowToInsert> rows, Map<Long,
+      List<BigQueryError>> failedRowsMap,
+      PartitionedTableId table) {
+    long index = 0;
+    Set<SinkRecord> recordsToDLQ = new TreeSet<>(rows.comparator());
+    Map<Long, List<BigQueryError>> recordsToDLQFailureMap = new TreeMap<>();
+    Map<Long, List<BigQueryError>> updatedFailedRowMap = new TreeMap<>();
+    for (Map.Entry<SinkRecord, InsertAllRequest.RowToInsert> row: rows.entrySet()) {
+      if (failedRowsMap.containsKey(index)) {
+        if (errantRecordHandler.isErrorReasonAllowed(failedRowsMap.get(index).get(0).getReason())) {
+          recordsToDLQ.add(row.getKey());
+          recordsToDLQFailureMap.put(index, failedRowsMap.get(index));
+        } else {
+          updatedFailedRowMap.put(index, failedRowsMap.get(index));
+        }
+      }
+      index++;
+    }
+
+    if (errantRecordHandler.getErrantRecordReporter() != null) {
+        errantRecordHandler.sendRecordsToDLQ(
+            recordsToDLQ,
+            new BigQueryConnectException(table.toString(), recordsToDLQFailureMap)
+        );
+    }
+
+    return updatedFailedRowMap;
+  }
+
+  /**
+   *
+   * @param failedRowsMap: A map from failed row index to the BigQueryError
+   * @return true if any row has Stopped BigQuery error else false.
+   */
+  private boolean hasStoppedErrorRecords(Map<Long, List<BigQueryError>> failedRowsMap) {
+    for (List<BigQueryError> errors : failedRowsMap.values()) {
+      if (!BigQueryErrorResponses.isStoppedError(errors.get(0))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 
@@ -49,9 +50,10 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    * @param bigQuery The object used to send write requests to BigQuery.
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
+   * @param errantRecordHandler Used to handle errant records
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait) {
-    super(retry, retryWait);
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, ErrantRecordHandler errantRecordHandler) {
+    super(retry, retryWait,errantRecordHandler);
     this.bigQuery = bigQuery;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -22,6 +22,7 @@ package com.wepay.kafka.connect.bigquery.write.row;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
@@ -46,18 +47,20 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
    *                                        given intermediate tables; used for create/update
    *                                        operations in order to propagate them to the destination
    *                                        table
+   * @param errantRecordHandler Used to handle errant records
    */
   public UpsertDeleteBigQueryWriter(BigQuery bigQuery,
                                     SchemaManager schemaManager,
                                     int retry,
                                     long retryWait,
                                     boolean autoCreateTables,
-                                    Map<TableId, TableId> intermediateToDestinationTables) {
+                                    Map<TableId, TableId> intermediateToDestinationTables,
+                                    ErrantRecordHandler errantRecordHandler) {
     // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
     // automatically created
     // The super class will handle all of the logic for writing to, creating, and updating
     // intermediate tables; this class will handle logic for creating/updating the destination table
-    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true);
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, errantRecordHandler);
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
     this.intermediateToDestinationTables = intermediateToDestinationTables;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/ErrantRecordHandlerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/ErrantRecordHandlerTest.java
@@ -1,0 +1,25 @@
+package com.wepay.kafka.connect.bigquery;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ErrantRecordHandlerTest {
+
+  @Test
+  public void shouldReturnTrueOnAllowedBigQueryReason() {
+    ErrantRecordHandler errantRecordHandler = new ErrantRecordHandler(null);
+    // should allow sending records to dlq for bigquery reason:invalid (present in
+    // allowedBigQueryErrorReason list)
+    boolean expected = errantRecordHandler.isErrorReasonAllowed("invalid");
+    Assert.assertTrue(expected);
+  }
+
+  @Test
+  public void shouldReturnFalseOnNonAllowedReason() {
+    ErrantRecordHandler errantRecordHandler = new ErrantRecordHandler(null);
+    // Should not allow sending records to dlq for reason not present in
+    // allowedBigQueryErrorReason list
+    boolean expected = errantRecordHandler.isErrorReasonAllowed("backendError");
+    Assert.assertFalse(expected);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -19,23 +19,6 @@
 
 package com.wepay.kafka.connect.bigquery.integration;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldValue;
@@ -56,10 +39,26 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.NoRetryException;
-import org.apache.kafka.test.TestUtils;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.cloud.bigquery.LegacySQLTypeName.BOOLEAN;
 import static com.google.cloud.bigquery.LegacySQLTypeName.BYTES;
@@ -130,7 +129,7 @@ public abstract class BaseConnectorIT {
   protected Map<String, String> baseConnectorProps(int tasksMax) {
     Map<String, String> result = new HashMap<>();
 
-    result.put(CONNECTOR_CLASS_CONFIG, "BigQuerySinkConnector");
+    result.put(CONNECTOR_CLASS_CONFIG, "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector");
     result.put(TASKS_MAX_CONFIG, Integer.toString(tasksMax));
 
     result.put(BigQuerySinkConfig.PROJECT_CONFIG, project());

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrantRecordHandlerIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrantRecordHandlerIT.java
@@ -1,0 +1,192 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.wepay.kafka.connect.bigquery.integration.utils.BigQueryTestUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+
+public class BigQueryErrantRecordHandlerIT extends BaseConnectorIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(BigQueryErrantRecordHandlerIT.class);
+  private static final String CONNECTOR_NAME = "kcbq-sink-connector";
+  private static final long NUM_RECORDS_PRODUCED = 20;
+
+  private BigQuery bigQuery;
+
+  @Before
+  public void setup() {
+    bigQuery = newBigQuery();
+    startConnect();
+  }
+
+  @After
+  public void close() {
+    bigQuery = null;
+    stopConnect();
+  }
+
+  @Test
+  public void testRecordsSentToDlqOnInvalidReason() throws InterruptedException {
+    final String topic = suffixedTableOrTopic("test-dlq-feature");
+    final String dlqTopic = "dlq_topic";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, 1);
+
+
+    final String table = sanitizedTable(topic);
+    // Create table schema
+    Schema schema = Schema.of(
+        Field.of("f1", StandardSQLTypeName.STRING),
+        Field.of("f2", StandardSQLTypeName.BOOL),
+        Field.of("f3", StandardSQLTypeName.INT64)
+    );
+
+    // Try to create BigQuery table
+    try {
+      BigQueryTestUtils.createPartitionedTable(bigQuery, dataset(), table, schema);
+    } catch (BigQueryException ex) {
+      if (!ex.getError().getReason().equalsIgnoreCase("duplicate"))
+        throw new ConnectException("Failed to create table: ", ex);
+      else
+        logger.info("Table {} already exist", table);
+    }
+
+    Map<String, String> props = connectorProps(topic, dlqTopic);
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send Invalid records to BigQuery
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      String kafkaKey = key(keyConverter, topic, i);
+      String kafkaValue = value(valueConverter, topic, i);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // Check records show up in dlq topic
+    ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(
+        (int) NUM_RECORDS_PRODUCED,
+        Duration.ofSeconds(120).toMillis(), dlqTopic);
+
+    Assert.assertEquals(NUM_RECORDS_PRODUCED, records.count());
+  }
+
+  @Test
+  public void testRecordsSentToDlqOnRecordConversionError() throws InterruptedException {
+    final String topic = suffixedTableOrTopic("test-dlq-feature");
+    final String dlqTopic = "dlq_topic";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, 1);
+
+    Map<String, String> props = connectorProps(topic, dlqTopic);
+    props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+    props.put("key.converter.schemas.enable", "false");
+    props.put("value.converter.schemas.enable", "false");
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+    // Send Invalid records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      String kafkaKey = "key-" + i;
+      String kafkaValue = "\"f1\":1";
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // Check records show up in dlq topic
+    ConsumerRecords<byte[], byte[]> records = connect.kafka().consume(
+        (int) NUM_RECORDS_PRODUCED,
+        Duration.ofSeconds(120).toMillis(), dlqTopic);
+
+    Assert.assertEquals(NUM_RECORDS_PRODUCED, records.count());
+  }
+
+  private Map<String, String> connectorProps(String topicName, String dlqTopicName) {
+    Map<String, String> result = baseConnectorProps(1);
+    result.put(SinkConnectorConfig.TOPICS_CONFIG, topicName);
+
+    // use the JSON converter with schemas enabled
+    result.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    result.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    // DLQ Error Handler Configs
+    result.put(SinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG, "true");
+    result.put(SinkConnectorConfig.ERRORS_TOLERANCE_CONFIG, "all");
+    result.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, dlqTopicName);
+    result.put(SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+    result.put(SinkConnectorConfig.DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
+
+    return result;
+  }
+
+  private Converter converter(boolean isKey) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, true);
+    Converter result = new JsonConverter();
+    result.configure(props, isKey);
+    return result;
+  }
+
+  private String key(Converter converter, String topic, long iteration) {
+    final org.apache.kafka.connect.data.Schema schema = SchemaBuilder.struct()
+        .field("k1", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+        .build();
+
+    final Struct struct = new Struct(schema)
+        .put("k1", iteration);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String value(Converter converter, String topic, int iteration) {
+    final org.apache.kafka.connect.data.Schema schema = SchemaBuilder.struct()
+        .optional()
+        .field("f1", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .field("f2", org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA)
+        .field("f3", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .build();
+
+    final Struct struct = new Struct(schema)
+        .put("f1", iteration % 2 == 0 ? "a string" : "another string")
+        .put("f2", iteration % 3 == 0)
+        .put("f3", "invalid value according to table schema");
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/BigQueryTestUtils.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/utils/BigQueryTestUtils.java
@@ -1,0 +1,40 @@
+package com.wepay.kafka.connect.bigquery.integration.utils;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TimePartitioning;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BigQueryTestUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(BigQueryTestUtils.class);
+
+  public static void createPartitionedTable(BigQuery bigQuery, String datasetName, String tableName,
+                                            Schema schema) {
+    try {
+      TableId tableId = TableId.of(datasetName, tableName);
+
+      TimePartitioning partitioning =
+          TimePartitioning.newBuilder(TimePartitioning.Type.DAY)
+              .build();
+
+      StandardTableDefinition tableDefinition =
+          StandardTableDefinition.newBuilder()
+              .setSchema(schema)
+              .setTimePartitioning(partitioning)
+              .build();
+      TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+      bigQuery.create(tableInfo);
+      logger.info("Partitioned table {} created successfully", tableName);
+    } catch (BigQueryException e) {
+      logger.error("Failed to create partitioned table {} in dataset {}", tableName, datasetName);
+      throw e;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
     <properties>
         <java.version>8</java.version>
 
-        <confluent.version>5.5.1</confluent.version>
+        <confluent.version>6.0.10</confluent.version>
         <debezium.version>0.6.2</debezium.version>
         <google.auth.version>0.21.1</google.auth.version>
         <google.cloud.version>2.10.9</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <google.protobuf.version>3.19.6</google.protobuf.version>
         <jackson.version>2.10.2</jackson.version>
-        <kafka.version>2.5.0</kafka.version>
+        <kafka.version>2.6.0</kafka.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <slf4j.version>1.7.26</slf4j.version>
         <caffeine.version>2.8.6</caffeine.version>


### PR DESCRIPTION
# Problem 
- There is an ask to implement KIP-610 feature in this connector which will allow sending errant records to DLQ and let connector run seamlessly without failing. 

# Solution
- The approach is discussed in this one-pager - https://confluentinc.atlassian.net/wiki/spaces/PM/pages/2975892760/One+Pager-+Adding+DLQ+Support+for+BigQuery+Sink+Connector+KIP-610
- Currently we are adding this support in case of Record Conversion failures and `Invalid` Reason response from bigquery endpoint. More details can be found in above one-pager. 

# Testing
- Manual testing via kafka-docker-playground by simulating the behaviour which sends errant records to DLQ.
- Added Unit test and Integration test for this feature. 

# Release plan
- Plan is to cut a minor branch and release a minor version - 2.5.0
- Onboard this new version to cloud 

