### PR TITLE
 Storage Write API Client library and configs addition

### DIFF
--- a/kcbq-api/pom.xml
+++ b/kcbq-api/pom.xml
@@ -42,10 +42,6 @@
             <artifactId>connect-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-bigquery</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -48,18 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-bigquery</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-storage</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-oauth2-http</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -329,6 +329,29 @@ public class BigQuerySinkConfig extends AbstractConfig {
       + "tables, and periodic merge flushes. Row-matching will be performed based on the contents " 
       + "of record keys.";
 
+  public static final String USE_STORAGE_WRITE_API_CONFIG = "useStorageWriteApi";
+
+  private static final ConfigDef.Type USE_STORAGE_WRITE_API_TYPE = ConfigDef.Type.BOOLEAN;
+  public static final boolean USE_STORAGE_WRITE_API_DEFAULT = true;
+  private static final ConfigDef.Importance USE_STORAGE_WRITE_API_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String USE_STORAGE_WRITE_API_DOC =
+          "Use Google's New Storage Write API for data streaming. Not available for upsert/delete mode";
+
+  public static final String ENABLE_BATCH_MODE_CONFIG = "enableBatchMode";
+  private static final ConfigDef.Type ENABLE_BATCH_MODE_TYPE = ConfigDef.Type.BOOLEAN;
+  public static final boolean ENABLE_BATCH_MODE_DEFAULT = false;
+  private static final ConfigDef.Importance ENABLE_BATCH_MODE_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String ENABLE_BATCH_MODE_DOC = "Use Google's New Storage Write API with batch mode";
+
+  public static final String COMMIT_INTERVAL_SEC_CONFIG = "commitInterval";
+  private static final ConfigDef.Type COMMIT_INTERVAL_SEC_TYPE = ConfigDef.Type.INT;
+  private static final Integer COMMIT_INTERVAL_SEC_DEFAULT = 60;
+
+  private static final ConfigDef.Validator COMMIT_INTERVAL_VALIDATOR = ConfigDef.Range.between(60, 14400); // currently allows 1 min -> 4 hours
+  private static final ConfigDef.Importance COMMIT_INTERVAL_SEC_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String COMMIT_INTERVAL_SEC_DOC =
+          "The interval, in seconds, in which to attempt to commit streamed records.";
+
   public static final String DELETE_ENABLED_CONFIG =                    "deleteEnabled";
   private static final ConfigDef.Type DELETE_ENABLED_TYPE =             ConfigDef.Type.BOOLEAN;
   public static final boolean DELETE_ENABLED_DEFAULT =                  false;
@@ -801,11 +824,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_CLUSTERING_FIELD_NAMES_VALIDATOR,
             BIGQUERY_CLUSTERING_FIELD_NAMES_IMPORTANCE,
             BIGQUERY_CLUSTERING_FIELD_NAMES_DOC
-        ).defineInternal(
-            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG,
-            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE,
-            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT,
-            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE
         ).define(
             TIME_PARTITIONING_TYPE_CONFIG,
             TIME_PARTITIONING_TYPE_TYPE,
@@ -843,11 +861,25 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_PARTITION_EXPIRATION_VALIDATOR,
             BIGQUERY_PARTITION_EXPIRATION_IMPORTANCE,
             BIGQUERY_PARTITION_EXPIRATION_DOC
-        ).defineInternal(
-                    CONNECTOR_RUNTIME_PROVIDER_CONFIG,
-                    CONNECTOR_RUNTIME_PROVIDER_TYPE,
-                    CONNECTOR_RUNTIME_PROVIDER_DEFAULT,
-                    CONNECTOR_RUNTIME_PROVIDER_IMPORTANCE
+        ).define(
+            USE_STORAGE_WRITE_API_CONFIG,
+            USE_STORAGE_WRITE_API_TYPE,
+            USE_STORAGE_WRITE_API_DEFAULT,
+            USE_STORAGE_WRITE_API_IMPORTANCE,
+            USE_STORAGE_WRITE_API_DOC
+        ).define(
+            ENABLE_BATCH_MODE_CONFIG,
+            ENABLE_BATCH_MODE_TYPE,
+            ENABLE_BATCH_MODE_DEFAULT,
+            ENABLE_BATCH_MODE_IMPORTANCE,
+            ENABLE_BATCH_MODE_DOC
+        ).define(
+            COMMIT_INTERVAL_SEC_CONFIG,
+            COMMIT_INTERVAL_SEC_TYPE,
+            COMMIT_INTERVAL_SEC_DEFAULT,
+            COMMIT_INTERVAL_VALIDATOR,
+            COMMIT_INTERVAL_SEC_IMPORTANCE,
+            COMMIT_INTERVAL_SEC_DOC
         ).define(
             MAX_RETRIES_CONFIG,
             MAX_RETRIES_TYPE,
@@ -860,6 +892,16 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ENABLE_RETRIES_TYPE,
             ENABLE_RETRIES_DEFAULT,
             ENABLE_RETRIES_IMPORTANCE
+        ).defineInternal(
+            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG,
+            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE,
+            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT,
+            CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE
+        ).defineInternal(
+            CONNECTOR_RUNTIME_PROVIDER_CONFIG,
+            CONNECTOR_RUNTIME_PROVIDER_TYPE,
+            CONNECTOR_RUNTIME_PROVIDER_DEFAULT,
+            CONNECTOR_RUNTIME_PROVIDER_IMPORTANCE
         );
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -295,4 +295,16 @@ public class BigQuerySinkConfigTest {
 
     new BigQuerySinkConfig(badConfigProperties);
   }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidCommitInterval() {
+    Map<String, String> badConfigProperties = propertiesFactory.getProperties();
+
+    badConfigProperties.put(
+            BigQuerySinkConfig.COMMIT_INTERVAL_SEC_CONFIG,
+            "0"
+    );
+
+    new BigQuerySinkConfig(badConfigProperties);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <checkstyle.plugin.version>2.15</checkstyle.plugin.version>
         <checkstyle.version>6.18</checkstyle.version>
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <google.cloud.bom.version>26.11.0</google.cloud.bom.version>
         <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
         <kafka.connect.plugin.version>0.11.1</kafka.connect.plugin.version>
         <release.plugin.version>2.5.3</release.plugin.version>
@@ -131,7 +132,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.11.0</version>
+                <version>${google.cloud.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>26.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Child projects -->
             <dependency>
                 <groupId>com.wepay.kcbq</groupId>
@@ -276,6 +283,12 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquerystorage</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,6 @@
 
         <confluent.version>6.0.10</confluent.version>
         <debezium.version>0.6.2</debezium.version>
-        <google.auth.version>0.21.1</google.auth.version>
-        <google.cloud.version>2.10.9</google.cloud.version>
-        <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
-        <google.protobuf.version>3.19.6</google.protobuf.version>
         <jackson.version>2.10.2</jackson.version>
         <kafka.version>2.6.0</kafka.version>
         <kafka.scala.version>2.12</kafka.scala.version>
@@ -159,22 +155,6 @@
                 <version>${kafka.version}</version>
                 <scope>provided</scope>
             </dependency>
-
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bigquery</artifactId>
-                <version>${google.cloud.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-storage</artifactId>
-                <version>${google.cloud.storage.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.auth</groupId>
-                <artifactId>google-auth-library-oauth2-http</artifactId>
-                <version>${google.auth.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -195,11 +175,6 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${google.protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -287,6 +262,14 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquerystorage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-bigquery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR updates Pom file to include client library and required configs for the new API. 
Includes - 
1. google cloud bom as documented here : https://cloud.google.com/bigquery/docs/reference/storage/libraries#install 
2. Cleanup of pinned protobuf-java and auth dependency as the latest bigquery version brings in  these.
3. Configs required from one-pager https://confluentinc.atlassian.net/wiki/spaces/CONNECT/pages/2961999467/Storage+Write+API+in+BQ+Sink+Connector#StorageWriteAPIinBQSinkConnector-User-FacingChanges 

JIRA tickets : https://confluentinc.atlassian.net/browse/CC-19645 , https://confluentinc.atlassian.net/browse/CC-19657 

Epic : https://confluentinc.atlassian.net/browse/CC-19644