### PR TITLE
Storage Write API Default stream resource cleanup on task shutdown

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
@@ -58,6 +58,16 @@ public abstract class StorageWriteApiBase {
         appendRows(tableName, rows, streamName);
     }
 
+    abstract public void preShutdown();
+
+    /**
+     * Gets called on task.stop() and should have resource cleanup logic.
+     */
+    public void shutdown() {
+        preShutdown();
+        this.writeClient.close();
+    }
+
     /**
      * @param tableName  The table to write data to
      * @param rows       The records to write

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStreamTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStreamTest.java
@@ -20,6 +20,8 @@ import org.mockito.ArgumentMatchers;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doNothing;
 
@@ -27,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
 public class StorageWriteApiDefaultStreamTest {
@@ -161,6 +164,14 @@ public class StorageWriteApiDefaultStreamTest {
         when(defaultStream.getAutoCreateTables()).thenReturn(true);
 
         verifyException(expectedException);
+    }
+
+    @Test
+    public void testShutdown() {
+        defaultStream.tableToStream = new ConcurrentHashMap<>();
+        defaultStream.tableToStream.put("testTable", mockedStreamWriter);
+        defaultStream.preShutdown();
+        verify(mockedStreamWriter, times(1)).close();
     }
 
     private void verifyException(String expectedException) {


### PR DESCRIPTION
This PR adds shutdown method which is responsible for closing all json writer opened in a task. 
This will be called by task.stop() method while shutting down.

JIRA : CC-19650
Epic : CC-19644
