### PR TITLE
Storage Write API Adds SinkTask Methods (start, put, stop)

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -230,6 +230,7 @@ public class BigQuerySinkTask extends SinkTask {
 
     return new String[]{dataset, tableName};
   }
+
   private PartitionedTableId getStorageApiRecordTable(String topic) {
     return topicToPartitionTableId.computeIfAbsent(topic, topicName -> {
       String project = config.getString(BigQuerySinkConfig.PROJECT_CONFIG);
@@ -238,6 +239,7 @@ public class BigQuerySinkTask extends SinkTask {
     });
 
   }
+
   private PartitionedTableId getRecordTable(SinkRecord record) {
     String[] datasetAndtableName = getDataSetAndTableName(record.topic());
     String dataset = datasetAndtableName[0];

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
@@ -53,6 +54,10 @@ import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import com.wepay.kafka.connect.bigquery.write.row.SimpleBigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.UpsertDeleteBigQueryWriter;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiWriter;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiBase;
+import com.wepay.kafka.connect.bigquery.write.storageApi.BigQueryWriteSettingsBuilder;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiDefaultStream;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
@@ -109,7 +114,7 @@ public class BigQuerySinkTask extends SinkTask {
 
   private KCBQThreadPoolExecutor executor;
   private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SEC = 30;
-  
+
   private final BigQuery testBigQuery;
   private final Storage testGcs;
   private final SchemaManager testSchemaManager;
@@ -123,6 +128,12 @@ public class BigQuerySinkTask extends SinkTask {
   private boolean enableRetries;
 
   private ErrantRecordHandler errantRecordHandler;
+  private boolean useStorageApi;
+  private StorageWriteApiBase storageApiWriter;
+  private int retry;
+  private long retryWait;
+  private final StorageWriteApiBase testStorageWriteApi;
+  private Map<String, PartitionedTableId> topicToPartitionTableId;
 
   /**
    * Create a new BigquerySinkTask.
@@ -132,6 +143,7 @@ public class BigQuerySinkTask extends SinkTask {
     schemaRetriever = null;
     testGcs = null;
     testSchemaManager = null;
+    testStorageWriteApi = null;
   }
 
   /**
@@ -144,12 +156,14 @@ public class BigQuerySinkTask extends SinkTask {
    * @see BigQuerySinkTask#BigQuerySinkTask()
    */
   public BigQuerySinkTask(BigQuery testBigQuery, SchemaRetriever schemaRetriever, Storage testGcs,
-                          SchemaManager testSchemaManager, Map<TableId, Table> testCache) {
+                          SchemaManager testSchemaManager, Map<TableId, Table> testCache,
+                          StorageWriteApiBase testStorageWriteApi) {
     this.testBigQuery = testBigQuery;
     this.schemaRetriever = schemaRetriever;
     this.testGcs = testGcs;
     this.testSchemaManager = testSchemaManager;
     this.cache = testCache;
+    this.testStorageWriteApi = testStorageWriteApi;
   }
 
   @Override
@@ -188,13 +202,13 @@ public class BigQuerySinkTask extends SinkTask {
     return offsets;
   }
 
-  private PartitionedTableId getRecordTable(SinkRecord record) {
+  private String[] getDataSetAndTableName(String topic) {
     String tableName;
     String dataset = config.getString(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG);
     if (topic2TableMap != null) {
-      tableName = topic2TableMap.getOrDefault(record.topic(), record.topic());
+      tableName = topic2TableMap.getOrDefault(topic, topic);
     } else {
-      String[] smtReplacement = record.topic().split(":");
+      String[] smtReplacement = topic.split(":");
 
       if (smtReplacement.length == 2) {
         dataset = smtReplacement[0];
@@ -206,7 +220,7 @@ public class BigQuerySinkTask extends SinkTask {
                 "Incorrect regex replacement format in topic name '%s'. "
                         + "SMT replacement should either produce the <dataset>:<tableName> format "
                         + "or just the <tableName> format.",
-                record.topic()
+                topic
         ));
       }
       if (sanitize) {
@@ -214,6 +228,20 @@ public class BigQuerySinkTask extends SinkTask {
       }
     }
 
+    return new String[]{dataset, tableName};
+  }
+  private PartitionedTableId getStorageApiRecordTable(String topic) {
+    return topicToPartitionTableId.computeIfAbsent(topic, topicName -> {
+      String project = config.getString(BigQuerySinkConfig.PROJECT_CONFIG);
+      String[] datasetAndtableName = getDataSetAndTableName(topicName);
+      return new PartitionedTableId.Builder(TableId.of(project, datasetAndtableName[0], datasetAndtableName[1])).build();
+    });
+
+  }
+  private PartitionedTableId getRecordTable(SinkRecord record) {
+    String[] datasetAndtableName = getDataSetAndTableName(record.topic());
+    String dataset = datasetAndtableName[0];
+    String tableName = datasetAndtableName[1];
     // TODO: Order of execution of topic/table name modifications =>
     // regex router SMT modifies topic name in sinkrecord.
     // It could be either : separated or not.
@@ -265,10 +293,17 @@ public class BigQuerySinkTask extends SinkTask {
 
     for (SinkRecord record : records) {
       if (record.value() != null || config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)) {
-        PartitionedTableId table = getRecordTable(record);
+        PartitionedTableId table = useStorageApi ? getStorageApiRecordTable(record.topic()) : getRecordTable(record);
         if (!tableWriterBuilders.containsKey(table)) {
           TableWriterBuilder tableWriterBuilder;
-          if (config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).contains(record.topic())) {
+          if (useStorageApi) {
+            tableWriterBuilder = new StorageWriteApiWriter.Builder(
+                    storageApiWriter,
+                    TableNameUtils.tableName(table.getBaseTableId()),
+                    config.getRecordConverter(),
+                    config
+            );
+          } else if (config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String topic = record.topic();
             long offset = record.kafkaOffset();
             String gcsBlobName = topic + "_" + uuid + "_" + Instant.now().toEpochMilli() + "_" + offset;
@@ -447,8 +482,6 @@ public class BigQuerySinkTask extends SinkTask {
     boolean autoCreateTables = config.getBoolean(BigQuerySinkConfig.TABLE_CREATE_CONFIG);
     boolean allowNewBigQueryFields = config.getBoolean(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
     boolean allowRequiredFieldRelaxation = config.getBoolean(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
-    int retry = config.getInt(BigQuerySinkConfig.BIGQUERY_RETRY_CONFIG);
-    long retryWait = config.getLong(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG);
     BigQuery bigQuery = getBigQuery();
     if (upsertDelete) {
       return new UpsertDeleteBigQueryWriter(bigQuery,
@@ -481,8 +514,6 @@ public class BigQuerySinkTask extends SinkTask {
 
   private GCSToBQWriter getGcsWriter() {
     BigQuery bigQuery = getBigQuery();
-    int retry = config.getInt(BigQuerySinkConfig.BIGQUERY_RETRY_CONFIG);
-    long retryWait = config.getLong(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG);
     boolean autoCreateTables = config.getBoolean(BigQuerySinkConfig.TABLE_CREATE_CONFIG);
     // schemaManager shall only be needed for creating table hence do not fetch instance if not
     // needed.
@@ -516,6 +547,10 @@ public class BigQuerySinkTask extends SinkTask {
     upsertDelete = config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)
         || config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG);
 
+    useStorageApi = config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG);
+    retry = config.getInt(BigQuerySinkConfig.BIGQUERY_RETRY_CONFIG);
+    retryWait = config.getLong(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG);
+    topicToPartitionTableId = new HashMap<>();
     bigQuery = new AtomicReference<>();
     schemaManager = new AtomicReference<>();
 
@@ -557,6 +592,8 @@ public class BigQuerySinkTask extends SinkTask {
       mergeQueries =
           new MergeQueries(config, mergeBatches, executor, getBigQuery(), getSchemaManager(), context);
       maybeStartMergeFlushTask();
+    } else if(useStorageApi) {
+      initializeStorageApiBasicMode();
     }
 
     recordConverter = getConverter(config);
@@ -565,6 +602,23 @@ public class BigQuerySinkTask extends SinkTask {
     enableRetries = config.getBoolean(BigQuerySinkConfig.ENABLE_RETRIES_CONFIG);
   }
 
+  private void initializeStorageApiBasicMode() {
+    if(testStorageWriteApi != null) {
+      logger.info("Starting task with Test Storage Write API Default Stream...");
+      storageApiWriter = testStorageWriteApi;
+    } else {
+      logger.info("Starting task with Storage Write API Default Stream...");
+      BigQueryWriteSettings writeSettings = new BigQueryWriteSettingsBuilder().withConfig(config).build();
+      storageApiWriter = new StorageWriteApiDefaultStream(
+              retry,
+              retryWait,
+              writeSettings,
+              config.getBoolean(BigQuerySinkConfig.TABLE_CREATE_CONFIG),
+              errantRecordHandler,
+              getSchemaManager()
+      );
+    }
+  }
   private void startGCSToBQLoadTask() {
     logger.info("Attempting to start GCS Load Executor.");
     loadExecutor = Executors.newScheduledThreadPool(1);
@@ -614,6 +668,8 @@ public class BigQuerySinkTask extends SinkTask {
           logger.debug("Deleting {}", intTable(table));
           getBigQuery().delete(table);
         });
+      } else if (useStorageApi) {
+        storageApiWriter.shutdown();
       }
     } finally {
       stopped = true;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -52,7 +52,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import java.net.SocketTimeoutException;
-import org.apache.kafka.common.config.ConfigException;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiDefaultStream;
 
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -85,6 +85,8 @@ public class BigQuerySinkTaskTest {
   private static SinkTaskPropertiesFactory propertiesFactory;
 
   private static AtomicLong spoofedRecordOffset = new AtomicLong();
+
+  private static StorageWriteApiDefaultStream mockedStorageWriteApiDefaultStream = mock(StorageWriteApiDefaultStream.class);
 
   @BeforeClass
   public static void initializePropertiesFactory() {
@@ -126,7 +128,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -160,7 +162,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -196,7 +198,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -217,7 +219,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.start(properties);
 
     testTask.put(Collections.emptyList());
@@ -240,7 +242,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.start(properties);
 
     SinkRecord emptyRecord = spoofSinkRecord(topic, simpleSchema, null);
@@ -272,7 +274,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -310,7 +312,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     
@@ -347,7 +349,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic, "value", "message text",
@@ -384,7 +386,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -447,7 +449,7 @@ public class BigQuerySinkTaskTest {
       return null;
     });
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -488,7 +490,7 @@ public class BigQuerySinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
 
     BigQuerySinkTask testTask =
-        new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+        new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -515,7 +517,7 @@ public class BigQuerySinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -537,7 +539,7 @@ public class BigQuerySinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -578,7 +580,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -616,7 +618,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -657,7 +659,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -695,7 +697,7 @@ public class BigQuerySinkTaskTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -727,7 +729,7 @@ public class BigQuerySinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -760,7 +762,7 @@ public class BigQuerySinkTaskTest {
     Storage storage = mock(Storage.class);
     BigQuery bigQuery  = mock(BigQuery.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage, null, tableCache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage, null, tableCache, mockedStorageWriteApiDefaultStream);
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
@@ -799,7 +801,7 @@ public class BigQuerySinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
 
     Storage storage = mock(Storage.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
@@ -1,0 +1,124 @@
+package com.wepay.kafka.connect.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.Table;
+
+import com.google.cloud.storage.Storage;
+
+import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiDefaultStream;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class BigQueryStorageApiSinkTaskTest {
+    private static final SinkTaskPropertiesFactory propertiesFactory = new SinkTaskPropertiesFactory();
+    Map<String, String> properties;
+    private static AtomicLong spoofedRecordOffset = new AtomicLong();
+    private static StorageWriteApiDefaultStream mockedStorageWriteApiDefaultStream = mock(
+            StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
+    ;
+    final String topic = "test_topic";
+    BigQuery bigQuery = mock(BigQuery.class);
+
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Map<TableId, Table> cache = new HashMap<>();
+    BigQuerySinkTask testTask = new BigQuerySinkTask(
+            bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
+
+    @Before
+    public void setUp() {
+        spoofedRecordOffset.set(0);
+        properties = propertiesFactory.getProperties();
+
+        properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+        properties.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+        properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+        spoofedRecordOffset.set(0);
+
+        doNothing().when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(), eq(null));
+        doNothing().when(mockedStorageWriteApiDefaultStream).shutdown();
+
+        testTask.initialize(sinkTaskContext);
+        testTask.start(properties);
+    }
+
+    @Test
+    public void testPut() {
+        testTask.put(Collections.singletonList(spoofSinkRecord()));
+        testTask.flush(Collections.emptyMap());
+
+        verify(mockedStorageWriteApiDefaultStream, times(1)).appendRows(any(), any(), eq(null));
+    }
+
+    @Test(expected = BigQueryConnectException.class)
+    public void testSimplePutException() throws Exception {
+        BigQueryStorageWriteApiConnectException exception = new BigQueryStorageWriteApiConnectException("error 12345");
+
+        doThrow(exception).when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(),eq(null));
+
+        testTask.put(Collections.singletonList(spoofSinkRecord()));
+        try {
+            while (true) {
+                Thread.sleep(100);
+                testTask.put(Collections.emptyList());
+            }
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof BigQueryStorageWriteApiConnectException);
+            throw e;
+        }
+    }
+
+    @Test(expected = RejectedExecutionException.class)
+    public void testStop() {
+        testTask.stop();
+
+        verify(mockedStorageWriteApiDefaultStream, times(1)).shutdown();
+
+        testTask.put(Collections.singletonList(spoofSinkRecord()));
+    }
+
+    private SinkRecord spoofSinkRecord() {
+
+        Schema basicValueSchema = SchemaBuilder
+                .struct()
+                .field("sink_task_test_field", Schema.STRING_SCHEMA)
+                .build();
+        Struct basicValue = new Struct(basicValueSchema);
+        basicValue.put("sink_task_test_field", "sink task test row");
+
+
+        return new SinkRecord(topic, 0, null, null,
+                basicValueSchema, basicValue, spoofedRecordOffset.getAndIncrement(), null, TimestampType.NO_TIMESTAMP_TYPE);
+    }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -46,7 +46,7 @@ public class SinkPropertiesFactory {
 
     properties.put(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, "false");
     properties.put(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, "false");
-
+    properties.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "false");
     return properties;
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -139,7 +139,7 @@ public abstract class BaseConnectorIT {
     result.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource());
 
     result.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-
+    result.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "false");
     return result;
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -46,6 +46,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiDefaultStream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -68,6 +69,7 @@ import java.util.Set;
 @SuppressWarnings("unchecked")
 public class BigQueryWriterTest {
   private static SinkPropertiesFactory propertiesFactory;
+  private static StorageWriteApiDefaultStream mockedStorageWriteApiDefaultStream = mock(StorageWriteApiDefaultStream.class);
 
   @BeforeClass
   public static void initializePropertiesFactory() {
@@ -100,7 +102,7 @@ public class BigQueryWriterTest {
     Storage storage = mock(Storage.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(
@@ -136,7 +138,7 @@ public class BigQueryWriterTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(
@@ -172,7 +174,7 @@ public class BigQueryWriterTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(
@@ -216,7 +218,7 @@ public class BigQueryWriterTest {
     Map<TableId, Table> cache = new HashMap<>();
     Storage storage = mock(Storage.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(sinkRecordList);
@@ -269,7 +271,7 @@ public class BigQueryWriterTest {
     Map<TableId, Table> cache = new HashMap<>();
     Storage storage = mock(Storage.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(sinkRecordList);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -31,6 +31,7 @@ import com.wepay.kafka.connect.bigquery.SinkPropertiesFactory;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiDefaultStream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -55,6 +56,8 @@ public class GCSToBQWriterTest {
 
   private static SinkPropertiesFactory propertiesFactory;
 
+  private static StorageWriteApiDefaultStream mockedStorageWriteApiDefaultStream = mock(StorageWriteApiDefaultStream.class);
+
   @BeforeClass
   public static void initializePropertiesFactory() {
     propertiesFactory = new SinkPropertiesFactory();
@@ -76,7 +79,7 @@ public class GCSToBQWriterTest {
     SchemaManager schemaManager = mock(SchemaManager.class);
     Map<TableId, Table> cache = new HashMap<>();
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(
@@ -106,7 +109,7 @@ public class GCSToBQWriterTest {
         .thenThrow(new StorageException(500, "internal server error")) // throw first time
         .thenReturn(null); // return second time. (we don't care about the result.)
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(
@@ -135,7 +138,7 @@ public class GCSToBQWriterTest {
     when(storage.create((BlobInfo)anyObject(), (byte[])anyObject()))
         .thenThrow(new StorageException(500, "internal server error"));
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiDefaultStream);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(


### PR DESCRIPTION
This PR adds
-> Task start for creating default stream 
-> Task put to send records via new api if configured
-> Task stop for cleaning up resources
-> Corresponding unit tests
-> Fixes unit tests failure due to newly added validations

JIRA: CC-19795

Epic: CC-19644