### PR TITLE
Storage Write api mode validation

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -919,6 +919,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
     MULTI_PROPERTY_VALIDATIONS.add(new GcsBucketValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new PartitioningModeValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new PartitioningTypeValidator());
+    MULTI_PROPERTY_VALIDATIONS.add(new StorageWriteApiValidator());
+    MULTI_PROPERTY_VALIDATIONS.add(new StorageWriteApiValidator.StorageWriteApiBatchValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new UpsertDeleteValidator.UpsertValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new UpsertDeleteValidator.DeleteValidator());
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
@@ -5,7 +5,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.*;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DELETE_ENABLED_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_MODE_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.UPSERT_ENABLED_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG;
 
 public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
@@ -13,13 +13,13 @@ import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STO
 
 public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
 
-    public static String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API." +
+    public static final String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API." +
             " Either disable Upsert mode or disable Storage Write API";
-    public static String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API." +
+    public static final String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API." +
             " Either disable Legacy Batch mode or disable Storage Write API";
-    public static String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is " +
+    public static final String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is " +
             "enabled. Either disable batch mode or enable Storage Write API";
-    public static String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode " +
+    public static final String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode " +
             "or disable Storage Write API";
     private static final Collection<String> DEPENDENTS = Collections.unmodifiableCollection(Arrays.asList(
             UPSERT_ENABLED_CONFIG, DELETE_ENABLED_CONFIG, ENABLE_BATCH_CONFIG

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
@@ -1,0 +1,61 @@
+package com.wepay.kafka.connect.bigquery.config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.*;
+
+public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
+
+    private static final Collection<String> DEPENDENTS = Collections.unmodifiableCollection(Arrays.asList(
+            UPSERT_ENABLED_CONFIG, DELETE_ENABLED_CONFIG, ENABLE_BATCH_CONFIG
+    ));
+
+    protected StorageWriteApiValidator(String propertyName) {
+        super(propertyName);
+    }
+
+    protected StorageWriteApiValidator() {
+        super(USE_STORAGE_WRITE_API_CONFIG);
+    }
+
+    @Override
+    protected Collection<String> dependents() {
+        return DEPENDENTS;
+    }
+
+    @Override
+    protected Optional<String> doValidate(BigQuerySinkConfig config) {
+        if (!config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)) {
+            if (config.getBoolean(ENABLE_BATCH_MODE_CONFIG)) {
+                return Optional.of("Storage Write Api Batch load is supported only when "
+                        + USE_STORAGE_WRITE_API_CONFIG + " is enabled. Either disable batch mode or enable Storage Write" +
+                        " API");
+            }
+            //No legacy modes validation needed if not using new api
+            return Optional.empty();
+        }
+        if (config.getBoolean(UPSERT_ENABLED_CONFIG)) {
+            return Optional.of(
+                    "Upsert mode is not supported with Storage Write API." +
+                            " Either disable Upsert mode or disable Storage Write API");
+        } else if (config.getBoolean(DELETE_ENABLED_CONFIG)) {
+            return Optional.of(
+                    "Delete mode is not supported with Storage Write API." +
+                            " Either disable Delete mode or disable Storage Write API");
+        } else if (!config.getList(ENABLE_BATCH_CONFIG).isEmpty()) {
+            return Optional.of(
+                    "Legacy Batch mode is not supported with Storage Write API." +
+                            " Either disable Legacy Batch mode or disable Storage Write API");
+        }
+        return Optional.empty();
+    }
+
+    static class StorageWriteApiBatchValidator extends StorageWriteApiValidator {
+        StorageWriteApiBatchValidator() {
+            super(ENABLE_BATCH_MODE_CONFIG);
+        }
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
@@ -13,6 +13,14 @@ import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STO
 
 public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
 
+    public static String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API." +
+            " Either disable Upsert mode or disable Storage Write API";
+    public static String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API." +
+            " Either disable Legacy Batch mode or disable Storage Write API";
+    public static String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is " +
+            "enabled. Either disable batch mode or enable Storage Write API";
+    public static String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode " +
+            "or disable Storage Write API";
     private static final Collection<String> DEPENDENTS = Collections.unmodifiableCollection(Arrays.asList(
             UPSERT_ENABLED_CONFIG, DELETE_ENABLED_CONFIG, ENABLE_BATCH_CONFIG
     ));
@@ -34,25 +42,17 @@ public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySin
     protected Optional<String> doValidate(BigQuerySinkConfig config) {
         if (!config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)) {
             if (config.getBoolean(ENABLE_BATCH_MODE_CONFIG)) {
-                return Optional.of("Storage Write Api Batch load is supported only when "
-                        + USE_STORAGE_WRITE_API_CONFIG + " is enabled. Either disable batch mode or enable Storage Write" +
-                        " API");
+                return Optional.of(newBatchNotSupportedError);
             }
             //No legacy modes validation needed if not using new api
             return Optional.empty();
         }
         if (config.getBoolean(UPSERT_ENABLED_CONFIG)) {
-            return Optional.of(
-                    "Upsert mode is not supported with Storage Write API." +
-                            " Either disable Upsert mode or disable Storage Write API");
+            return Optional.of(upsertNotSupportedError);
         } else if (config.getBoolean(DELETE_ENABLED_CONFIG)) {
-            return Optional.of(
-                    "Delete mode is not supported with Storage Write API." +
-                            " Either disable Delete mode or disable Storage Write API");
+            return Optional.of(deleteNotSupportedError);
         } else if (!config.getList(ENABLE_BATCH_CONFIG).isEmpty()) {
-            return Optional.of(
-                    "Legacy Batch mode is not supported with Storage Write API." +
-                            " Either disable Legacy Batch mode or disable Storage Write API");
+            return Optional.of(legacyBatchNotSupportedError);
         }
         return Optional.empty();
     }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
@@ -1,6 +1,10 @@
 package com.wepay.kafka.connect.bigquery.config;
 
-import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.*;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DELETE_ENABLED_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_MODE_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.UPSERT_ENABLED_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -12,6 +16,15 @@ import java.util.Collections;
 import java.util.Optional;
 
 public class StorageWriteApiValidatorTest {
+
+    String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API." +
+            " Either disable Upsert mode or disable Storage Write API";
+    String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API." +
+            " Either disable Legacy Batch mode or disable Storage Write API";
+    String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is " +
+            "enabled. Either disable batch mode or enable Storage Write API";
+    String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode " +
+            "or disable Storage Write API";
 
     @Test
     public void testNoStorageWriteApiEnabled() {
@@ -44,9 +57,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
 
         assertEquals(
-                Optional.of(
-                        "Upsert mode is not supported with Storage Write API." +
-                                " Either disable Upsert mode or disable Storage Write API"),
+                Optional.of(upsertNotSupportedError),
                 new StorageWriteApiValidator().doValidate(config));
     }
 
@@ -59,10 +70,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(true);
         when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
 
-        assertEquals(Optional.of(
-                        "Delete mode is not supported with Storage Write API." +
-                                " Either disable Delete mode or disable Storage Write API"),
-                new StorageWriteApiValidator().doValidate(config));
+        assertEquals(Optional.of(deleteNotSupportedError), new StorageWriteApiValidator().doValidate(config));
     }
 
     @Test
@@ -74,10 +82,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(false);
         when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
 
-        assertEquals(Optional.of(
-                        "Legacy Batch mode is not supported with Storage Write API." +
-                                " Either disable Legacy Batch mode or disable Storage Write API"),
-                new StorageWriteApiValidator().doValidate(config));
+        assertEquals(Optional.of(legacyBatchNotSupportedError), new StorageWriteApiValidator().doValidate(config));
     }
 
     @Test
@@ -87,9 +92,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(false);
         when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
 
-        assertEquals(Optional.of(
-                        "Storage Write Api Batch load is supported only when useStorageWriteApi is enabled. Either" +
-                                " disable batch mode or enable Storage Write API"),
+        assertEquals(Optional.of(newBatchNotSupportedError),
                 new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
     }
 
@@ -100,7 +103,8 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
         when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
 
-        assertEquals(Optional.empty(), new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
+        assertEquals(Optional.empty(),
+                new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
     }
 
     @Test
@@ -111,9 +115,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
         when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
 
-        assertEquals(Optional.of(
-                        "Storage Write Api Batch load is supported only when useStorageWriteApi is enabled. Either" +
-                                " disable batch mode or enable Storage Write API"),
+        assertEquals(Optional.of(newBatchNotSupportedError),
                 new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
     }
 
@@ -125,10 +127,7 @@ public class StorageWriteApiValidatorTest {
         when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
         when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
 
-        assertEquals(Optional.of(
-                        "Legacy Batch mode is not supported with Storage Write API." +
-                                " Either disable Legacy Batch mode or disable Storage Write API"),
-                new StorageWriteApiValidator().doValidate(config));
+        assertEquals(Optional.of(legacyBatchNotSupportedError), new StorageWriteApiValidator().doValidate(config));
     }
 }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
@@ -11,20 +11,14 @@ import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
+import static com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidator.legacyBatchNotSupportedError;
+import static com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidator.upsertNotSupportedError;
+import static com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidator.deleteNotSupportedError;
+import static com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidator.newBatchNotSupportedError;
 import java.util.Collections;
 import java.util.Optional;
 
 public class StorageWriteApiValidatorTest {
-
-    String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API." +
-            " Either disable Upsert mode or disable Storage Write API";
-    String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API." +
-            " Either disable Legacy Batch mode or disable Storage Write API";
-    String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is " +
-            "enabled. Either disable batch mode or enable Storage Write API";
-    String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode " +
-            "or disable Storage Write API";
 
     @Test
     public void testNoStorageWriteApiEnabled() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
@@ -1,0 +1,134 @@
+package com.wepay.kafka.connect.bigquery.config;
+
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.*;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class StorageWriteApiValidatorTest {
+
+    @Test
+    public void testNoStorageWriteApiEnabled() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(false);
+
+        assertEquals(Optional.empty(), new StorageWriteApiValidator().doValidate(config));
+    }
+
+    @Test
+    public void testNoLegacyModesEnabled() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(UPSERT_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
+
+        assertEquals(Optional.empty(), new StorageWriteApiValidator().doValidate(config));
+    }
+
+    @Test
+    public void testUpsertModeEnabled() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(UPSERT_ENABLED_CONFIG)).thenReturn(true);
+        when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
+
+        assertEquals(
+                Optional.of(
+                        "Upsert mode is not supported with Storage Write API." +
+                                " Either disable Upsert mode or disable Storage Write API"),
+                new StorageWriteApiValidator().doValidate(config));
+    }
+
+    @Test
+    public void testDeleteModeEnabled() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(UPSERT_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(true);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
+
+        assertEquals(Optional.of(
+                        "Delete mode is not supported with Storage Write API." +
+                                " Either disable Delete mode or disable Storage Write API"),
+                new StorageWriteApiValidator().doValidate(config));
+    }
+
+    @Test
+    public void testLegacyBatchModeEnabled() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(UPSERT_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(false);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
+
+        assertEquals(Optional.of(
+                        "Legacy Batch mode is not supported with Storage Write API." +
+                                " Either disable Legacy Batch mode or disable Storage Write API"),
+                new StorageWriteApiValidator().doValidate(config));
+    }
+
+    @Test
+    public void testNewBatchModeEnabledWithoutNewApi() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(false);
+        when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
+
+        assertEquals(Optional.of(
+                        "Storage Write Api Batch load is supported only when useStorageWriteApi is enabled. Either" +
+                                " disable batch mode or enable Storage Write API"),
+                new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
+    }
+
+    @Test
+    public void testNewBatchModeEnabledWithNewApi() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
+
+        assertEquals(Optional.empty(), new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
+    }
+
+    @Test
+    public void testBothLegacyAndNewBatchEnabledOldApi() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(false);
+        when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
+
+        assertEquals(Optional.of(
+                        "Storage Write Api Batch load is supported only when useStorageWriteApi is enabled. Either" +
+                                " disable batch mode or enable Storage Write API"),
+                new StorageWriteApiValidator.StorageWriteApiBatchValidator().doValidate(config));
+    }
+
+    @Test
+    public void testBothLegacyAndNewBatchEnabledNewApi() {
+        BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+
+        when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+        when(config.getBoolean(ENABLE_BATCH_MODE_CONFIG)).thenReturn(true);
+        when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.singletonList("abc"));
+
+        assertEquals(Optional.of(
+                        "Legacy Batch mode is not supported with Storage Write API." +
+                                " Either disable Legacy Batch mode or disable Storage Write API"),
+                new StorageWriteApiValidator().doValidate(config));
+    }
+}
+


### PR DESCRIPTION
This PR adds validation checks for Storage Write API basic and batch mode.

- New api cannot be clubbed with any of legacy modes
- New Batch mode can only be enabled if connector is configured to use new api. 
- Unit tests to test the validation

JIRA : CC-19905
EPIC: CC-19644