### PR TITLE
Increasing Jenkins build timeout to 3 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,5 +26,5 @@ common {
           ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE'],
           ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'GOOGLE_APPLICATION_CREDENTIALS']
   ]
-  timeoutHours = 2
+  timeoutHours = 3
 }


### PR DESCRIPTION
Due to addition of more Integration tests for Storage Write API, the build is failing at 2 hours due to timeout.
This PR increases the Jenkins build timeout to 3 hours to handle the time duration increased by new tests. 