### PR TITLE
Fixes Storage Write API default stream java docs

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
@@ -68,7 +68,7 @@ public abstract class StorageWriteApiBase {
     /**
      * Handles required initialization steps and goes to append records to table
      * @param tableName  The table to write data to
-     * @param rows       List of records in <{@link org.apache.kafka.connect.sink.SinkRecord}, {@link org.json.JSONObject}>
+     * @param rows       List of records in {@link org.apache.kafka.connect.sink.SinkRecord}, {@link org.json.JSONObject}
      *                   format. JSONObjects would be sent to api. SinkRecords are requireed for DLQ routing
      * @param streamName The stream to use to write table to table.
      */
@@ -137,7 +137,7 @@ public abstract class StorageWriteApiBase {
     }
 
     /**
-     * @param rows Rows of <SinkRecord, JSONObject > format
+     * @param rows Rows of {SinkRecord, JSONObject} format
      * @return Returns list of all SinkRecords
      */
     protected List<SinkRecord> getSinkRecords(List<Object[]> rows) {
@@ -152,9 +152,9 @@ public abstract class StorageWriteApiBase {
 
     /**
      * Sends errant records to configured DLQ and returns remaining
-     * @param input List of <SinkRecord, JSONObject> input data
+     * @param input List of SinkRecord, JSONObject input data
      * @param indexToErrorMap Map of record index to error received from api call
-     * @return Returns list of good <Sink, JSONObject> filtered from input which needs to be retried. Append row does
+     * @return Returns list of good Sink, JSONObject filtered from input which needs to be retried. Append row does
      * not write partially even if there is a single failure, good data has to be retried
      */
     protected List<Object[]> sendErrantRecordsToDlqAndFilterValidRecords(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStream.java
@@ -102,7 +102,7 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
      * Calls AppendRows and handles exception if the ingestion fails
      *
      * @param tableName  The table to write data to
-     * @param rows       List of records in <{@link org.apache.kafka.connect.sink.SinkRecord}, {@link org.json.JSONObject}>
+     * @param rows       List of records in {@link org.apache.kafka.connect.sink.SinkRecord}, {@link org.json.JSONObject}
      *                   format. JSONObjects would be sent to api. SinkRecords are requireed for DLQ routing
      * @param streamName The stream to use to write table to table. This will be DEFAULT always.
      */


### PR DESCRIPTION
This PR fixes malformed entries from Javadoc. 
Release on 2.6.x is failing due to bad error. Please take a look at the detailed logs for build #2324

```
error: malformed HTML
error: bad use of '>'

```