### PR TITLE
Storage Write API: changes stream name from null to default 

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
@@ -29,6 +29,8 @@ public class StorageWriteApiWriter implements Runnable {
     private final List<Object[]> records;
     private final String streamName;
 
+    public static final String DEFAULT= "default";
+
     /**
      *
      * @param tableName The table to write the records to
@@ -109,7 +111,7 @@ public class StorageWriteApiWriter implements Runnable {
          */
         @Override
         public Runnable build() {
-            return new StorageWriteApiWriter(tableName, streamWriter, records, "default");
+            return new StorageWriteApiWriter(tableName, streamWriter, records, DEFAULT);
         }
     }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
@@ -109,7 +109,7 @@ public class StorageWriteApiWriter implements Runnable {
          */
         @Override
         public Runnable build() {
-            return new StorageWriteApiWriter(tableName, streamWriter, records, null);
+            return new StorageWriteApiWriter(tableName, streamWriter, records, "default");
         }
     }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
@@ -28,7 +28,6 @@ public class StorageWriteApiWriter implements Runnable {
     private final TableName tableName;
     private final List<Object[]> records;
     private final String streamName;
-
     public static final String DEFAULT= "default";
 
     /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
@@ -66,7 +66,7 @@ public class BigQueryStorageApiSinkTaskTest {
         properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
         spoofedRecordOffset.set(0);
 
-        doNothing().when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(), eq(null));
+        doNothing().when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(), eq("default"));
         doNothing().when(mockedStorageWriteApiDefaultStream).shutdown();
 
         testTask.initialize(sinkTaskContext);
@@ -78,14 +78,14 @@ public class BigQueryStorageApiSinkTaskTest {
         testTask.put(Collections.singletonList(spoofSinkRecord()));
         testTask.flush(Collections.emptyMap());
 
-        verify(mockedStorageWriteApiDefaultStream, times(1)).appendRows(any(), any(), eq(null));
+        verify(mockedStorageWriteApiDefaultStream, times(1)).appendRows(any(), any(), eq("default"));
     }
 
     @Test(expected = BigQueryConnectException.class)
     public void testSimplePutException() throws Exception {
         BigQueryStorageWriteApiConnectException exception = new BigQueryStorageWriteApiConnectException("error 12345");
 
-        doThrow(exception).when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(),eq(null));
+        doThrow(exception).when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(),eq("default"));
 
         testTask.put(Collections.singletonList(spoofSinkRecord()));
         try {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiSinkTaskTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static com.wepay.kafka.connect.bigquery.write.storageApi.StorageWriteApiWriter.DEFAULT;
 
 public class BigQueryStorageApiSinkTaskTest {
     private static final SinkTaskPropertiesFactory propertiesFactory = new SinkTaskPropertiesFactory();
@@ -66,7 +67,7 @@ public class BigQueryStorageApiSinkTaskTest {
         properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
         spoofedRecordOffset.set(0);
 
-        doNothing().when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(), eq("default"));
+        doNothing().when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(), eq(DEFAULT));
         doNothing().when(mockedStorageWriteApiDefaultStream).shutdown();
 
         testTask.initialize(sinkTaskContext);
@@ -78,14 +79,14 @@ public class BigQueryStorageApiSinkTaskTest {
         testTask.put(Collections.singletonList(spoofSinkRecord()));
         testTask.flush(Collections.emptyMap());
 
-        verify(mockedStorageWriteApiDefaultStream, times(1)).appendRows(any(), any(), eq("default"));
+        verify(mockedStorageWriteApiDefaultStream, times(1)).appendRows(any(), any(), eq(DEFAULT));
     }
 
     @Test(expected = BigQueryConnectException.class)
     public void testSimplePutException() throws Exception {
         BigQueryStorageWriteApiConnectException exception = new BigQueryStorageWriteApiConnectException("error 12345");
 
-        doThrow(exception).when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(),eq("default"));
+        doThrow(exception).when(mockedStorageWriteApiDefaultStream).appendRows(any(), any(),eq(DEFAULT));
 
         testTask.put(Collections.singletonList(spoofSinkRecord()));
         try {


### PR DESCRIPTION
This PR updates 'null' to default in case of default streams. This change only improves trace logging as this string is not used anywhere else. 