### PR TITLE
BugFix: Routes failed records to DLQ if connector is not configured to perform schema updates

### DIFF
--- a/kcbq-connector/quickstart/avro-console-producer.sh
+++ b/kcbq-connector/quickstart/avro-console-producer.sh
@@ -24,8 +24,68 @@ if [ -z $CONFLUENT_DIR ]; then
   CONFLUENT_DIR="$BASE_DIR/../../confluent-3.0.0"
 fi
 
-KAFKA_TOPIC='kcbq-quickstart'
+KAFKA_TOPIC='timestamp_issue'
+KAFKA_TOPIC_2='five'
 AVRO_SCHEMA='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
+#AVRO_SCHEMA='{"type":"record","name":"myrecord","fields":[{
+#                                                                "name": "f1",
+#                                                                "type": {
+#                                                                          "type": "array",
+#                                                                          "items": "string"
+#                                                                          }
+#                                                              }
+#
+#
+#                                                              ]}'
+#AVRO_SCHEMA='{"type":"record","name":"myrecord","fields":[{
+#                                                                "name": "f1",
+#                                                                "type": "bytes"
+#                                                          },{
+#                                                                "name": "f2",
+#                                                                "type": "boolean"
+#                                                              }
+#
+#
+#                                                              ]}'
+#AVRO_SCHEMA='{"type":"record","name":"myrecord","fields":[{
+#                                                                "name": "ordertime",
+#                                                                "type": "long"
+#                                                              },
+#                                                              {
+#                                                                "name": "orderid",
+#                                                                "type": "int"
+#                                                              },
+#                                                              {
+#                                                                "name": "itemid",
+#                                                                 "type": "string"
+#                                                              },
+#                                                              {
+#                                                                "name": "orderunits",
+#                                                                "type": "double"
+#                                                              },
+#
+#                                                              {
+#                                                                "name": "address",
+#                                                                "type": {
+#                                                                  "connect.name": "ksql.address",
+#                                                                  "fields": [
+#                                                                    {
+#                                                                      "name": "city",
+#                                                                      "type": "string"
+#                                                                    },
+#                                                                    {
+#                                                                      "name": "state",
+#                                                                      "type": "string"
+#                                                                    },
+#                                                                    {
+#                                                                      "name": "zipcode",
+#                                                                      "type": "long"
+#                                                                    }
+#                                                                  ],
+#                                                                  "name": "address",
+#                                                                  "type": "record"
+#                                                                }
+#                                                              }]}'
 REGISTRY_URL='http://localhost:8081'
 BROKER_LIST='localhost:9092'
 
@@ -97,9 +157,43 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+export CONFLUENT_DIR=~/confluent-7.3.0
 
+#FILE_NAME='/Users/bhagyashree/Utilities/order_key.txt'
+#while true; do
+#    while read line; do
+#      echo $line
+#      done < $FILE_NAME | exec "$CONFLUENT_DIR/bin/kafka-avro-console-producer" \
+#        --broker-list "$BROKER_LIST" \
+#        --topic "$KAFKA_TOPIC" \
+#        --property key.schema="$AVRO_KEY_SCHEMA" \
+#        --property value.schema="$AVRO_SCHEMA" \
+#        -property "parse.key=true" \
+#        --property "key.separator=@" \
+#        --property schema.registry.url="$REGISTRY_URL"
+#break
+##      echo "Iteration next"
+#done
+###
 exec "$CONFLUENT_DIR/bin/kafka-avro-console-producer" \
-    --broker-list "$BROKER_LIST" \
-    --topic "$KAFKA_TOPIC" \
-    --property value.schema="$AVRO_SCHEMA" \
-    --property schema.registry.url="$REGISTRY_URL"
+        --broker-list "$BROKER_LIST" \
+        --topic "$KAFKA_TOPIC" \
+        --property value.schema="$AVRO_SCHEMA" \
+        --property schema.registry.url="$REGISTRY_URL"
+
+#        {"ordertime": 167817698691600,"orderid": 0,"itemid": "Item_1","orderunits": 1678176.986916,"address": { "city": "City_1","state": "State_","zipcode": 10100010001001}}
+
+#/*
+#
+#{"f1":"113"}
+#{"f1":"1113"}
+#{"f1":"2"}
+#{"f1":"20"}
+#{"f1":"200"}
+#{"f1":"2000"}
+#{"f1":"20000"}
+#
+#{"f1":"114"}
+#{"f1":"1114"}
+#{"f1":"14"}
+#*/

--- a/kcbq-connector/quickstart/properties/connector.properties
+++ b/kcbq-connector/quickstart/properties/connector.properties
@@ -17,14 +17,12 @@
 # under the License.
 #
 
-name=bigquery-connector
+name=bigquery-connector0
 connector.class=com.wepay.kafka.connect.bigquery.BigQuerySinkConnector
 tasks.max=1
 
-topics=kcbq-quickstart
-sanitizeTopics=true
-
-autoUpdateSchemas=true
+topics=timestamp_issue
+sanitizeTopics=false
 
 schemaRetriever=com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever
 
@@ -39,8 +37,33 @@ transforms.RegexTransformation.replacement=$2
 
 ########################################### Fill me in! ###########################################
 # The name of the BigQuery project to write to
-project=
+project=cloud-private-dev
 # The name of the default BigQuery dataset to write to
-defaultDataset=
+defaultDataset=bgoyal_manual_testing
 # The location of a BigQuery service account JSON key file
-keyfile=
+keyfile=/Users/bhagyashree/Downloads/cloud-private-dev-8f8a0417f646.json
+
+useStorageWriteApi=false
+
+autoCreateTables=true
+bigQueryRetry=3
+#errors.deadletterqueue.topic.name=dlq_b5
+#errors.deadletterqueue.context.headers.enable=true
+#errors.deadletterqueue.topic.replication.factor=1
+#errors.tolerance=all
+#errors.log.enable=true
+#
+allowNewBigQueryFields=true
+allowBigQueryRequiredFieldRelaxation=true
+allowSchemaUnionization=true
+bigQueryPartitionDecorator=false
+#
+#enableBatchLoad=test102
+#gcsBucketName=bgoyal_test_bucket
+#upsertEnabled=true
+#deleteEnabled=true
+#kafkaKeyFieldName=f1
+#enableBatchMode=true
+##commitInterval=180
+#kafkaKeyFieldName=i_am_record
+kafkaDataFieldName=i_am_detail

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBase.java
@@ -35,6 +35,7 @@ public abstract class StorageWriteApiBase {
     private final boolean autoCreateTables;
     private final Random random;
     private final BigQueryWriteSettings writeSettings;
+    private final boolean attemptSchemaUpdate;
 
     /**
      * @param retry               How many retries to make in the event of a retriable error.
@@ -48,7 +49,8 @@ public abstract class StorageWriteApiBase {
                                BigQueryWriteSettings writeSettings,
                                boolean autoCreateTables,
                                ErrantRecordHandler errantRecordHandler,
-                               SchemaManager schemaManager) {
+                               SchemaManager schemaManager,
+                               boolean attemptSchemaUpdate) {
         this.retry = retry;
         this.retryWait = retryWait;
         this.autoCreateTables = autoCreateTables;
@@ -56,7 +58,7 @@ public abstract class StorageWriteApiBase {
         this.writeSettings = writeSettings;
         this.errantRecordHandler = errantRecordHandler;
         this.schemaManager = schemaManager;
-
+        this.attemptSchemaUpdate = attemptSchemaUpdate;
         try {
             this.writeClient = getWriteClient();
         } catch (IOException e) {
@@ -134,6 +136,10 @@ public abstract class StorageWriteApiBase {
 
     protected boolean getAutoCreateTables() {
         return this.autoCreateTables;
+    }
+
+    protected  boolean canAttemptSchemaUpdate() {
+        return this.attemptSchemaUpdate;
     }
 
     /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStreamTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiDefaultStreamTest.java
@@ -110,6 +110,7 @@ public class StorageWriteApiDefaultStreamTest {
         when(defaultStream.getErrantRecordHandler()).thenReturn(mockedErrantRecordHandler);
         when(mockedErrantRecordHandler.getErrantRecordReporter()).thenReturn(mockedErrantReporter);
         when(defaultStream.getAutoCreateTables()).thenReturn(true);
+        when(defaultStream.canAttemptSchemaUpdate()).thenReturn(true);
     }
 
     @Test
@@ -170,6 +171,17 @@ public class StorageWriteApiDefaultStreamTest {
         verify(mockedSchemaManager, times(1)).updateSchema(any(), any());
 
     }
+
+    @Test(expected = BigQueryStorageWriteApiConnectException.class)
+    public void testHasSchemaUpdatesNotConfigured() throws Exception {
+        when(mockedResponse.get()).thenReturn(schemaError).thenReturn(successResponse);
+        when(defaultStream.canAttemptSchemaUpdate()).thenReturn(false);
+
+        defaultStream.appendRows(mockedTableName, testRows, null);
+
+        verify(mockedSchemaManager, times(1)).updateSchema(any(), any());
+    }
+
     @Test(expected = BigQueryStorageWriteApiConnectException.class)
     public void testDefaultStreamNonRetriableException() throws Exception {
         InterruptedException exception = new InterruptedException("I am non-retriable error");


### PR DESCRIPTION
We tried to update schema even if the connector is not configured to handle schema updates. This fails in later steps when configs are not set. 
This PR fixes the bug by adding a check to only perform schema update if connector is configured, otherwise routes the failed routes to DLQ.  If the DLQ is not configured, the task would fail as expected. 
Manual testing has been performed for following cases - 
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>

Schema Config | DLQ Config | Result
-- | -- | --
Yes | No | Schema update
No | No | Task fail
Yes | Yes | Schema update
No | Yes | DLQ routing

