### PR TITLE
BugFix: Storage Write API TImeStamp schema type accepts int64(long). 

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -78,7 +78,7 @@ public class KafkaDataBuilder {
      * @param kafkaConnectRecord Kafka sink record to build kafka data from.
      * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime in microseconds.
      */
-    public static Map<String, Object> buildKafkaDataRecordSorageApi(SinkRecord kafkaConnectRecord) {
+    public static Map<String, Object> buildKafkaDataRecordStorageApi(SinkRecord kafkaConnectRecord) {
         Map<String, Object> kafkaData = buildKafkaDataRecord(kafkaConnectRecord);
         kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() * 1000);
         return kafkaData;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -72,4 +72,16 @@ public class KafkaDataBuilder {
         return kafkaData;
     }
 
+    /**
+     * Construct a map of Kafka Data record for sending to Storage Write API
+     *
+     * @param kafkaConnectRecord Kafka sink record to build kafka data from.
+     * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime in microseconds.
+     */
+    public static Map<String, Object> buildKafkaDataRecordSorageApi(SinkRecord kafkaConnectRecord) {
+        Map<String, Object> kafkaData = buildKafkaDataRecord(kafkaConnectRecord);
+        kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() * 1000);
+        return kafkaData;
+    }
+
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
@@ -90,7 +90,7 @@ public class StorageWriteApiWriter implements Runnable {
             Map<String, Object> convertedRecord = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
             config.getKafkaDataFieldName().ifPresent(
-                    fieldName -> convertedRecord.put(fieldName, KafkaDataBuilder.buildKafkaDataRecordSorageApi(record))
+                    fieldName -> convertedRecord.put(fieldName, KafkaDataBuilder.buildKafkaDataRecordStorageApi(record))
             );
 
             config.getKafkaKeyFieldName().ifPresent(fieldName -> {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriter.java
@@ -90,7 +90,7 @@ public class StorageWriteApiWriter implements Runnable {
             Map<String, Object> convertedRecord = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
             config.getKafkaDataFieldName().ifPresent(
-                    fieldName -> convertedRecord.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record))
+                    fieldName -> convertedRecord.put(fieldName, KafkaDataBuilder.buildKafkaDataRecordSorageApi(record))
             );
 
             config.getKafkaKeyFieldName().ifPresent(fieldName -> {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -67,7 +67,7 @@ public class KafkaDataConverterTest {
     @Test
     public void testBuildKafkaDataRecordStorageWriteApi() {
         SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
-        Map<String, Object> actualKafkaDataFields = KafkaDataBuilder.buildKafkaDataRecordSorageApi(record);
+        Map<String, Object> actualKafkaDataFields = KafkaDataBuilder.buildKafkaDataRecordStorageApi(record);
 
         assertTrue(actualKafkaDataFields.containsKey(kafkaDataInsertTimeName));
         assertTrue(actualKafkaDataFields.get(kafkaDataInsertTimeName) instanceof Long);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -23,6 +23,7 @@ package com.wepay.kafka.connect.bigquery.convert;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -38,24 +39,36 @@ public class KafkaDataConverterTest {
     private static final String kafkaDataPartitionName = "partition";
     private static final String kafkaDataOffsetName = "offset";
     private static final String kafkaDataInsertTimeName = "insertTime";
-
-    @Test
-    public void testBuildKafkaDataRecord() {
-
-        final String kafkaDataTopicValue = "testTopic";
-        final int kafkaDataPartitionValue = 101;
-        final long kafkaDataOffsetValue = 1337;
-
-        Map<String, Object> expectedKafkaDataFields = new HashMap<>();
+    Map<String, Object> expectedKafkaDataFields = new HashMap<>();
+    private static final String kafkaDataTopicValue = "testTopic";
+    private static final int kafkaDataPartitionValue = 101;
+    private static final long kafkaDataOffsetValue = 1337;
+    @Before
+    public void setup() {
         expectedKafkaDataFields.put(kafkaDataTopicName, kafkaDataTopicValue);
         expectedKafkaDataFields.put(kafkaDataPartitionName, kafkaDataPartitionValue);
         expectedKafkaDataFields.put(kafkaDataOffsetName, kafkaDataOffsetValue);
-
+    }
+    @Test
+    public void testBuildKafkaDataRecord() {
         SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
         Map<String, Object> actualKafkaDataFields = KafkaDataBuilder.buildKafkaDataRecord(record);
 
         assertTrue(actualKafkaDataFields.containsKey(kafkaDataInsertTimeName));
         assertTrue(actualKafkaDataFields.get(kafkaDataInsertTimeName) instanceof Double);
+
+        actualKafkaDataFields.remove(kafkaDataInsertTimeName);
+
+        assertEquals(expectedKafkaDataFields, actualKafkaDataFields);
+    }
+
+    @Test
+    public void testBuildKafkaDataRecordStorageWriteApi() {
+        SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+        Map<String, Object> actualKafkaDataFields = KafkaDataBuilder.buildKafkaDataRecordSorageApi(record);
+
+        assertTrue(actualKafkaDataFields.containsKey(kafkaDataInsertTimeName));
+        assertTrue(actualKafkaDataFields.get(kafkaDataInsertTimeName) instanceof Long);
 
         actualKafkaDataFields.remove(kafkaDataInsertTimeName);
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -43,12 +43,14 @@ public class KafkaDataConverterTest {
     private static final String kafkaDataTopicValue = "testTopic";
     private static final int kafkaDataPartitionValue = 101;
     private static final long kafkaDataOffsetValue = 1337;
+
     @Before
     public void setup() {
         expectedKafkaDataFields.put(kafkaDataTopicName, kafkaDataTopicValue);
         expectedKafkaDataFields.put(kafkaDataPartitionName, kafkaDataPartitionValue);
         expectedKafkaDataFields.put(kafkaDataOffsetName, kafkaDataOffsetValue);
     }
+
     @Test
     public void testBuildKafkaDataRecord() {
         SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriterTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiWriterTest.java
@@ -15,12 +15,14 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
 
@@ -45,9 +47,9 @@ public class StorageWriteApiWriterTest {
         expectedKeys.add("name");
         expectedKeys.add("available_name");
         expectedKeys.add("i_am_kafka_key");
+        expectedKeys.add("i_am_kafka_record_detail");
 
-
-        Mockito.when(mockedConfig.getKafkaDataFieldName()).thenReturn(Optional.empty());
+        Mockito.when(mockedConfig.getKafkaDataFieldName()).thenReturn(Optional.of("i_am_kafka_record_detail"));
         Mockito.when(mockedConfig.getKafkaKeyFieldName()).thenReturn(Optional.of("i_am_kafka_key"));
         Mockito.when(mockedConfig.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG)).thenReturn(true);
 
@@ -63,6 +65,9 @@ public class StorageWriteApiWriterTest {
 
         String actualKafkaKey = actual.get("i_am_kafka_key").toString();
         assertEquals(expectedKafkaKey, actualKafkaKey);
+
+        JSONObject recordDetails = (JSONObject) actual.get("i_am_kafka_record_detail");
+        assertTrue(recordDetails.get("insertTime") instanceof Long);
     }
 
     private SinkRecord createRecord(String topic, long offset) {


### PR DESCRIPTION
Legacy API sends kafka record details with insertTime as double. This logic was kept same but during testing it was found not working. 
After working with Google support team we got to know that the new API expects int(64)/microsecond timestamp  snd double is not supported. (Documented here - https://cloud.google.com/bigquery/docs/write-api#data_type_conversions)
This is a single usage in the connector where we are adding timestamp value. 

JIRA: CC-20247