### PR TITLE
Added support for custom metrics

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/Metrics.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/Metrics.java
@@ -1,0 +1,74 @@
+package com.wepay.kafka.connect.bigquery.metrics;
+
+import io.debezium.annotation.ThreadSafe;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+
+@ThreadSafe
+public abstract class Metrics {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
+    private final ObjectName name;
+    private volatile boolean registered = false;
+
+    protected Metrics(String taskId) {
+        this.name = this.metricName(taskId);
+    }
+
+    public synchronized void register() {
+        try {
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            if (mBeanServer == null) {
+                LOGGER.info("JMX not supported, bean '{}' not registered", this.name);
+            } else {
+                if (!mBeanServer.isRegistered(this.name)) {
+                    // StandardMBean mbean = new StandardMBean(bqSinkConnectorMetrics, BqSinkConnectorMetricsMXBean.class);
+                    try {
+                        mBeanServer.registerMBean(this, this.name);
+                    } catch (InstanceAlreadyExistsException ex1) {
+                        LOGGER.error("Failed to register metrics MBean, as an old set with the same name exists, metrics will not be available", ex1);
+                    } catch (MBeanRegistrationException ex2) {
+                        LOGGER.error("Failed to register metrics MBean, metrics will not be available", ex2);
+                    }
+                }
+                this.registered = true;
+            }
+        } catch (NotCompliantMBeanException ex) {
+            LOGGER.error("Failed to create Standard MBean, metrics will not be available", ex);
+        }
+    }
+
+    public synchronized void unregister() {
+        if (this.name != null && this.registered) {
+            try {
+                MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+                if (mBeanServer == null) {
+                    LOGGER.debug("JMX not supported, bean '{}' not registered", this.name);
+                    return;
+                }
+
+                try {
+                    mBeanServer.unregisterMBean(this.name);
+                } catch (InstanceNotFoundException var3) {
+                    LOGGER.info("Unable to unregister metrics MBean '{}' as it was not found", this.name);
+                }
+
+                this.registered = false;
+            } catch (JMException var4) {
+                throw new RuntimeException("Unable to unregister the MBean '" + this.name + "'", var4);
+            }
+        }
+    }
+
+    protected ObjectName metricName(String taskId) {
+        String metricName = "kafka.connect:type=bqsink-connector-metrics,taskid=" + taskId;
+        try {
+            return new ObjectName(metricName);
+        } catch (MalformedObjectNameException var5) {
+            throw new ConnectException("Invalid metric name '" + metricName + "'");
+        }
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/MetricsEventPublisher.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/MetricsEventPublisher.java
@@ -1,0 +1,32 @@
+package com.wepay.kafka.connect.bigquery.metrics;
+
+import com.wepay.kafka.connect.bigquery.metrics.events.MetricEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public class MetricsEventPublisher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsEventPublisher.class);
+    private final Map<Class<? extends MetricEvent>, Consumer<? extends MetricEvent>> subscribes = new ConcurrentHashMap<>();
+
+    public <T extends MetricEvent> void publishMetricEvent(T metricEvent) {
+        Consumer<T> consumer = (Consumer<T>) subscribes.get(metricEvent.getClass());
+        if (consumer != null) {
+            try {
+                consumer.accept(metricEvent);
+            } catch (Exception ex) {
+                LOGGER.warn("Failed to process metric event: " + metricEvent, ex);
+            }
+        }
+    }
+
+    public <T extends MetricEvent> void subscribe(Class<T> clazz, Consumer<T> consumer) {
+        if (subscribes.containsKey(clazz)) {
+            throw new IllegalStateException();
+        }
+        subscribes.put(clazz, consumer);
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/BQLoaderRunStatusEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/BQLoaderRunStatusEvent.java
@@ -1,0 +1,14 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public class BQLoaderRunStatusEvent implements MetricEvent {
+
+    private final boolean isSuccessfulBQLoaderRun;
+
+    public BQLoaderRunStatusEvent(boolean isSuccessfulBQLoaderRun) {
+        this.isSuccessfulBQLoaderRun = isSuccessfulBQLoaderRun;
+    }
+
+    public boolean isSuccessfulBQLoaderRun() {
+        return isSuccessfulBQLoaderRun;
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/LoadJobStatusEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/LoadJobStatusEvent.java
@@ -1,0 +1,26 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public class LoadJobStatusEvent implements MetricEvent {
+
+    private final int numberOfActiveLoadJobs;
+    private final int numberOfSuccessfulLoadJobs;
+    private final int numberOfFailedLoadJobs;
+
+    public LoadJobStatusEvent(int numberOfActiveLoadJobs, int numberOfSuccessfulLoadJobs, int numberOfFailedLoadJobs) {
+        this.numberOfActiveLoadJobs = numberOfActiveLoadJobs;
+        this.numberOfSuccessfulLoadJobs = numberOfSuccessfulLoadJobs;
+        this.numberOfFailedLoadJobs = numberOfFailedLoadJobs;
+    }
+
+    public int getNumberOfActiveLoadJobs() {
+        return numberOfActiveLoadJobs;
+    }
+
+    public int getNumberOfSuccessfulLoadJobs() {
+        return numberOfSuccessfulLoadJobs;
+    }
+
+    public int getNumberOfFailedLoadJobs() {
+        return numberOfFailedLoadJobs;
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/MetricEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/MetricEvent.java
@@ -1,0 +1,4 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public interface MetricEvent {
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageBlobDeleteOperationStatusEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageBlobDeleteOperationStatusEvent.java
@@ -1,0 +1,20 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public class StorageBlobDeleteOperationStatusEvent implements MetricEvent {
+
+    private final int numberOfSuccessfullyDeletedBlobs;
+    private final int numberOfFailedDeletedBlobs;
+
+    public StorageBlobDeleteOperationStatusEvent(int numberOfSuccessfullyDeletedBlobs, int numberOfFailedDeletedBlobs) {
+        this.numberOfSuccessfullyDeletedBlobs = numberOfSuccessfullyDeletedBlobs;
+        this.numberOfFailedDeletedBlobs = numberOfFailedDeletedBlobs;
+    }
+
+    public int getNumberOfSuccessfullyDeletedBlobs() {
+        return numberOfSuccessfullyDeletedBlobs;
+    }
+
+    public int getNumberOfFailedDeletedBlobs() {
+        return numberOfFailedDeletedBlobs;
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageBlobsStatusEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageBlobsStatusEvent.java
@@ -1,0 +1,26 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public class StorageBlobsStatusEvent implements MetricEvent {
+
+    private final long totalNumberOfBlobsInStorage;
+    private final int claimedNumberOfBlobsInStorage;
+    private final int deletableNumberOfBlobsInStorage;
+
+    public StorageBlobsStatusEvent(long totalNumberOfBlobsInStorage, int claimedNumberOfBlobsInStorage, int deletableNumberOfBlobsInStorage) {
+        this.totalNumberOfBlobsInStorage = totalNumberOfBlobsInStorage;
+        this.claimedNumberOfBlobsInStorage = claimedNumberOfBlobsInStorage;
+        this.deletableNumberOfBlobsInStorage = deletableNumberOfBlobsInStorage;
+    }
+
+    public long getTotalNumberOfBlobsInStorage() {
+        return totalNumberOfBlobsInStorage;
+    }
+
+    public int getClaimedNumberOfBlobsInStorage() {
+        return claimedNumberOfBlobsInStorage;
+    }
+
+    public int getDeletableNumberOfBlobsInStorage() {
+        return deletableNumberOfBlobsInStorage;
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageExceptionCountEvent.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/events/StorageExceptionCountEvent.java
@@ -1,0 +1,4 @@
+package com.wepay.kafka.connect.bigquery.metrics.events;
+
+public class StorageExceptionCountEvent implements MetricEvent {
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/jmx/BqSinkConnectorMetricsImpl.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/jmx/BqSinkConnectorMetricsImpl.java
@@ -1,0 +1,116 @@
+package com.wepay.kafka.connect.bigquery.metrics.jmx;
+
+import com.wepay.kafka.connect.bigquery.metrics.Metrics;
+import com.wepay.kafka.connect.bigquery.metrics.MetricsEventPublisher;
+import com.wepay.kafka.connect.bigquery.metrics.events.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class BqSinkConnectorMetricsImpl extends Metrics implements BqSinkConnectorMetricsMXBean {
+
+    private final AtomicInteger numberOfActiveLoadJobs = new AtomicInteger(0);
+    private final AtomicInteger numberOfSuccessfulLoadJobs = new AtomicInteger(0);
+    private final AtomicInteger numberOfFailedLoadJobs = new AtomicInteger(0);
+
+    // BQ-Loader Run status events
+    private final AtomicInteger successfulBQLoaderRunCounter = new AtomicInteger(0);
+    private final AtomicInteger failedBQLoaderRunCounter = new AtomicInteger(0);
+
+    // storage blobs status events
+    private final AtomicLong totalNumberOfBlobsInStorage = new AtomicLong(0);
+    private final AtomicInteger claimedNumberOfBlobsInStorage = new AtomicInteger(0);
+    private final AtomicInteger deletableNumberOfBlobsInStorage = new AtomicInteger(0);
+
+    // storage blob delete operation status event
+    private final AtomicInteger numberOfSuccessfullyDeletedStorageBlobs = new AtomicInteger(0);
+    private final AtomicInteger numberOfFailedDeletedStorageBlobs = new AtomicInteger(0);
+
+    // storage exception counter
+    private final AtomicInteger storageExceptionCounter = new AtomicInteger(0);
+
+    private final MetricsEventPublisher metricsEventPublisher;
+
+    public BqSinkConnectorMetricsImpl(String taskId) {
+        super(taskId);
+
+        this.metricsEventPublisher = new MetricsEventPublisher();
+
+        metricsEventPublisher.subscribe(LoadJobStatusEvent.class, event -> {
+            numberOfActiveLoadJobs.set(event.getNumberOfActiveLoadJobs());
+            numberOfSuccessfulLoadJobs.set(event.getNumberOfSuccessfulLoadJobs());
+            numberOfFailedLoadJobs.set(event.getNumberOfFailedLoadJobs());
+        });
+
+        metricsEventPublisher.subscribe(BQLoaderRunStatusEvent.class, event -> {
+            if (event.isSuccessfulBQLoaderRun()) {
+                successfulBQLoaderRunCounter.incrementAndGet();
+            } else {
+                failedBQLoaderRunCounter.incrementAndGet();
+            }
+        });
+
+        metricsEventPublisher.subscribe(StorageBlobsStatusEvent.class, event -> {
+            totalNumberOfBlobsInStorage.set(event.getTotalNumberOfBlobsInStorage());
+            claimedNumberOfBlobsInStorage.set(event.getClaimedNumberOfBlobsInStorage());
+            deletableNumberOfBlobsInStorage.set(event.getDeletableNumberOfBlobsInStorage());
+        });
+
+        metricsEventPublisher.subscribe(StorageBlobDeleteOperationStatusEvent.class, event -> {
+            numberOfSuccessfullyDeletedStorageBlobs.set(event.getNumberOfSuccessfullyDeletedBlobs());
+            numberOfFailedDeletedStorageBlobs.set(event.getNumberOfFailedDeletedBlobs());
+        });
+
+        metricsEventPublisher.subscribe(StorageExceptionCountEvent.class, event -> {
+            storageExceptionCounter.incrementAndGet();
+        });
+    }
+
+    public MetricsEventPublisher getMetricsEventPublisher() {
+        return this.metricsEventPublisher;
+    }
+
+    public int getNumberOfActiveLoadJobs() {
+        return numberOfActiveLoadJobs.get();
+    }
+
+    public int getNumberOfSuccessfulLoadJobs() {
+        return numberOfSuccessfulLoadJobs.get();
+    }
+
+    public int getNumberOfFailedLoadJobs() {
+        return numberOfFailedLoadJobs.get();
+    }
+
+    public int getSuccessfulBQLoaderRunCounter() {
+        return successfulBQLoaderRunCounter.get();
+    }
+
+    public int getFailedBQLoaderRunCounter() {
+        return failedBQLoaderRunCounter.get();
+    }
+
+    public long getTotalNumberOfBlobsInStorage() {
+        return totalNumberOfBlobsInStorage.get();
+    }
+
+    public int getClaimedNumberOfBlobsInStorage() {
+        return claimedNumberOfBlobsInStorage.get();
+    }
+
+    public int getDeletableNumberOfBlobsInStorage() {
+        return deletableNumberOfBlobsInStorage.get();
+    }
+
+    public int getNumberOfSuccessfullyDeletedStorageBlobs() {
+        return numberOfSuccessfullyDeletedStorageBlobs.get();
+    }
+
+    public int getNumberOfFailedDeletedStorageBlobs() {
+        return numberOfFailedDeletedStorageBlobs.get();
+    }
+
+    public int getStorageExceptionCounter() {
+        return storageExceptionCounter.get();
+    }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/jmx/BqSinkConnectorMetricsMXBean.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/metrics/jmx/BqSinkConnectorMetricsMXBean.java
@@ -1,0 +1,29 @@
+package com.wepay.kafka.connect.bigquery.metrics.jmx;
+
+import javax.management.MXBean;
+
+@MXBean
+public interface BqSinkConnectorMetricsMXBean {
+
+    int getNumberOfActiveLoadJobs();
+
+    int getNumberOfSuccessfulLoadJobs();
+
+    int getNumberOfFailedLoadJobs();
+
+    int getSuccessfulBQLoaderRunCounter();
+
+    int getFailedBQLoaderRunCounter();
+
+    long getTotalNumberOfBlobsInStorage();
+
+    int getClaimedNumberOfBlobsInStorage();
+
+    int getDeletableNumberOfBlobsInStorage();
+
+    int getNumberOfSuccessfullyDeletedStorageBlobs();
+
+    int getNumberOfFailedDeletedStorageBlobs();
+
+    int getStorageExceptionCounter();
+}


### PR DESCRIPTION
## Details
As of now the connector only exposes standard Kafka Connect MBeans metrics, but we do have lot of operations happening in connector runtime where we are missing observability. This PR adds support for exposing custom metrics from the connector runtime by adding custom JMX MBeans.

## Changes
* Added MXBean for exporting connector metrics through JMX
* Since connector Batch mode load-job-runnables do not have observability, added custom metrics to expose numbers around number of active jobs, storage-blobs etc.
* made custom metrics are easily expandable for metrics around various other elements of the connector

## Testing
Tested the exported metrics locally with the Jconsole, I am able to see metrics exported from all tasks of the connector.
<img width="1703" alt="Screenshot 2023-05-08 at 12 50 59 AM" src="https://user-images.githubusercontent.com/17931142/236911357-9de245c4-541c-4e6e-a137-f2f0f296ddb1.png">

## Note
- These custom metrics also facilitates later on adding alerts, for ex. any load-job failures, load-jobs getting triggered in regular intervals etc.
- code is expandable for adding more custom metrics from connector sink task
