### PR TITLE
Removes special chars from javadoc

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/StorageWriteApiBatchApplicationStream.java
@@ -40,7 +40,7 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiApplic
     private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBatchApplicationStream.class);
 
     /**
-     * Map of <tableName , <StreamName, {@link ApplicationStream}>>
+     * Map of {tableName , {StreamName, {@link ApplicationStream}}}
      * Streams should be accessed in the order of entry, so we need LinkedHashMap here
      */
     protected ConcurrentMap<String, LinkedHashMap<String, ApplicationStream>> streams;


### PR DESCRIPTION
Removes '<' and '>' from javadoc as release is failing. Build no 2369