### PR TITLE
Storage Write API Batch mode: Fail task when background thread throws an exception

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiBatchSinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiBatchSinkTaskTest.java
@@ -75,7 +75,7 @@ public class BigQueryStorageApiBatchSinkTaskTest {
     Map<TableId, Table> cache = new HashMap<>();
     BigQuerySinkTask testTask = new BigQuerySinkTask(
             bigQuery, schemaRetriever, storage, schemaManager, cache, mockedStorageWriteApiBatchStream, mockedBatchHandler);
-
+    BigQueryStorageWriteApiConnectException exception = new BigQueryStorageWriteApiConnectException("error 12345");
     final String topic = "test-topic";
 
     Map<TopicPartition, OffsetAndMetadata> mockedOffset = mock(Map.class);
@@ -120,10 +120,18 @@ public class BigQueryStorageApiBatchSinkTaskTest {
         verify(mockedBatchHandler, times(1)).createNewStream();
     }
 
+    @Test(expected = BigQueryStorageWriteApiConnectException.class)
+    public void testBatchLoadFailure() throws InterruptedException {
+        doThrow(exception).when(mockedBatchHandler).createNewStream();
+        Thread.sleep(12000); // 10 seconds is default, check after 12 seconds
+        while (true) {
+            Thread.sleep(100);
+            testTask.put(Collections.emptyList());
+        }
+    }
+
     @Test(expected = BigQueryConnectException.class)
     public void testSimplePutException() throws Exception {
-        BigQueryStorageWriteApiConnectException exception = new BigQueryStorageWriteApiConnectException("error 12345");
-
         doThrow(exception).when(mockedStorageWriteApiBatchStream).appendRows(any(), any(), eq("dummyStream"));
 
         testTask.put(Collections.singletonList(spoofSinkRecord()));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiBatchSinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQueryStorageApiBatchSinkTaskTest.java
@@ -153,7 +153,7 @@ public class BigQueryStorageApiBatchSinkTaskTest {
     }
 
 
-    @Test(expected = RejectedExecutionException.class)
+    @Test(expected = BigQueryStorageWriteApiConnectException.class)
     public void testStop() {
         testTask.stop();
 


### PR DESCRIPTION
Problem: Storage APi in batch mode relies on the background thread which creates new streams and commits the older streams every commitInterval. If due to any reasons this background thread encounters any exception, it stops any further processing. This happens silently and we are not informed. The connector keeps running and put method keeps on receiving data but we do not commit anything to bigquery tables.
Solution: We now fail the task on seeing any errors in background thread. 
A reference discussion for this probelm is [here](https://stackoverflow.com/questions/6894595/scheduledexecutorservice-exception-handling) but the suggestions were not applicable in our case.

JIRA: CC-20491