### PR TITLE
Storage Write API Bug Fix : Commit streams which close mid processing

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/ApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storageApi/ApplicationStream.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Plain JAVA class with all utility methods on Application streams.
@@ -49,7 +50,7 @@ public class ApplicationStream {
      * This is called by builder to capture maximum calls expected to append.
      */
     private final AtomicInteger maxCalls;
-    private final AtomicInteger totalRowsSent;
+    private final AtomicLong totalRowsSent;
     private List<String> committableStreams ;
 
     public ApplicationStream(String tableName, BigQueryWriteClient client) throws Exception {
@@ -59,7 +60,7 @@ public class ApplicationStream {
         this.appendCalls = new AtomicInteger();
         this.maxCalls = new AtomicInteger();
         this.completedCalls = new AtomicInteger();
-        this.totalRowsSent = new AtomicInteger();
+        this.totalRowsSent = new AtomicLong();
         this.committableStreams = new ArrayList<>();
         generateStream();
         currentState = StreamState.CREATED;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/ApplicationStreamIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/ApplicationStreamIT.java
@@ -108,6 +108,8 @@ public class ApplicationStreamIT extends BaseConnectorIT {
     public void testStreamFinalised() throws Exception {
         ApplicationStream applicationStream = new ApplicationStream(tableNameStr, client);
         applicationStream.increaseMaxCalls();
+        applicationStream.closeStream();
+        applicationStream.writer();
         assertEquals(applicationStream.getCurrentState(), StreamState.APPEND);
         applicationStream.finalise();
         assertEquals(applicationStream.getCurrentState(), StreamState.FINALISED);
@@ -118,6 +120,8 @@ public class ApplicationStreamIT extends BaseConnectorIT {
     public void testStreamCommitted() throws Exception {
         ApplicationStream applicationStream = new ApplicationStream(tableNameStr, client);
         applicationStream.increaseMaxCalls();
+        applicationStream.closeStream();
+        applicationStream.writer();
         applicationStream.finalise();
         assertEquals(applicationStream.getCurrentState(), StreamState.FINALISED);
         applicationStream.commit();


### PR DESCRIPTION
This PR fixes the data loss issue observed intermittently on devel for Storage Write API batch mode.

Cause: After investigation it was figured out that the stream got closed (we are still figuring out if this was initiated by our application or bigquery api) mid processing. The application recreated the stream but only committed the data carried by last stream.

Resolution: We are storing all streams created/recreated on an object and finalising and committing all at the end of processing.

Test:
Manual test
Integration test 