### PR TITLE
Fix duplicates with schema unionisation when column name case differs

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -396,7 +396,7 @@ public class SchemaManager {
       }
     }
 
-    checkState(firstField.getName().equals(secondField.getName()),
+    checkState(firstField.getName().equalsIgnoreCase(secondField.getName()),
             String.format("Cannot perform union operation on two fields having different names. " +
                     "Field names are '%s' and '%s'.", firstField.getName(), secondField.getName()));
     checkState(firstField.getType() == secondField.getType(),
@@ -478,7 +478,7 @@ public class SchemaManager {
     for (Map.Entry<String, Field> entry : proposedSchemaFields.entrySet()) {
       if (!earliestSchemaFields.containsKey(entry.getKey())) {
         if (!isValidFieldAddition(entry.getValue())) {
-          throw new BigQueryConnectException("New Field found with the name " + entry.getKey()
+          throw new BigQueryConnectException("New Field found with the name " + entry.getValue().getName()
               + " Ensure that " + BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG + " is true and "
               + BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG +
               " is true if " + entry.getKey() + " has mode REQUIRED in order to update the Schema");
@@ -548,7 +548,7 @@ public class SchemaManager {
       if (field.getMode() == null) {
         field = field.toBuilder().setMode(Mode.NULLABLE).build();
       }
-      result.put(field.getName(), field);
+      result.put(field.getName().toLowerCase(), field);
     });
     return result;
   }
@@ -565,7 +565,7 @@ public class SchemaManager {
       if (field.getMode() == null) {
         field = field.toBuilder().setMode(Field.Mode.NULLABLE).build();
       }
-      result.put(field.getName(), field);
+      result.put(field.getName().toLowerCase(), field);
     });
     return result;
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -905,6 +905,21 @@ public class SchemaManagerTest {
   }
 
   @Test
+  public void testUnionizeSchemaCaseInsensitive() {
+    com.google.cloud.bigquery.Schema s1 = com.google.cloud.bigquery.Schema.of(
+            Field.of("CAPS", LegacySQLTypeName.RECORD,
+                    Field.newBuilder(LegacySQLTypeName.STRING.name(), LegacySQLTypeName.STRING).setMode(Mode.REQUIRED).build()
+            )
+    );
+    com.google.cloud.bigquery.Schema s2 = com.google.cloud.bigquery.Schema.of(
+            Field.of("caps", LegacySQLTypeName.RECORD,
+                    Field.newBuilder(LegacySQLTypeName.STRING.name(), LegacySQLTypeName.STRING).setMode(Mode.NULLABLE).build()
+            )
+    );
+    assertUnion(makeNullable(s1), s1, s2);
+  }
+
+  @Test
   public void testFieldNameSanitizedOnCreateTable() {
     Schema embeddedStructWithInvalidFieldName = SchemaBuilder.struct()
         .field("embedded-invalid", Schema.INT32_SCHEMA)


### PR DESCRIPTION
**Issue -** 
The BigQuery iInk connector when configured with `allowSchemaUnionization` merges schema from BQ table and all the records of current batch and attempts schema update with unionized schema in BQ tables.
If the case of a field among table schema or any of the records schema does not match, connector today considers it as different column and tries to push all such entries in one schema request. This results in column `*** already exists in schema `errors from BigQuery.
**Fix -** 
SchemaManager maintains an internal map keyed with column names string and sends all the values of the map to bigquery. Have added `.toLowercase()` method on the map keys so the comparison can detect duplicates. Since the keys are used for internal processing, changing case would not be appearing on the BQ tables and the schema would appear as it appears today.

**Testing -** 
Unit test added.
Following manual testing done. 
<img width="2117" alt="Screenshot 2023-06-08 at 11 59 15 AM" src="https://github.com/confluentinc/kafka-connect-bigquery/assets/117655560/4ae013d7-ae10-4bbc-b81e-36fa18b4ae31">

**Release Strategy -**
This fix would be back-ported to 2.0.x and released to CP after cloud release and verification. 

JIRA: CC-20832
