### PR TITLE
Updates Jenkinsfile to add release requirements for external secrets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,14 +17,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+def getVaultSecretsList() {
+  return [
+          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE'],
+          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'GOOGLE_APPLICATION_CREDENTIALS']
+  ]
+}
+
 common {
   slackChannel = '#connect-warn'
   nodeLabel = 'docker-oraclejdk8'
   publish = false
   downStreamValidate = false
-  secret_file_list = [
-          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'KCBQ_TEST_KEYFILE'],
-          ['gcp/kcbq', 'creds',   '/tmp/creds.json', 'GOOGLE_APPLICATION_CREDENTIALS']
-  ]
+  secret_file_list = getVaultSecretsList()
   timeoutHours = 2
 }


### PR DESCRIPTION
Release job requires getVaultSecretsList() to be present if connector specific secrets loading is required.
JIRA: CC-21230 (contains the reference of why these changes are needed)