### PR TITLE
Update Jenkinsfile to use docker-debian-jdk8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ def getVaultSecretsList() {
 
 common {
   slackChannel = '#connect-warn'
-  nodeLabel = 'docker-oraclejdk8'
+  nodeLabel = 'docker-debian-jdk8'
   publish = false
   downStreamValidate = false
   secret_file_list = getVaultSecretsList()


### PR DESCRIPTION
## Problem
The existing Jenkins job fails to download the latest version of common-tools, which is needed for some standard Jenkins job logic.

## Solution
Use the `docker-debian-jdk8` node type instead of the existing one. This node type is as similar to the existing node type as possible and successfully downloads the latest version of common-tools. The same approach was taken on a similar repo a couple years ago: https://github.com/confluentinc/kafka-connect-sqs/pull/30

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
The 21 other references to this node: https://github.com/search?q=org%3Aconfluentinc+docker-oraclejdk8+NOT+is%3Aarchived&type=code

## Test Strategy
PR job makes it past the existing issue

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Merge to master and hope it works.