### PR TITLE
[Test - do not merge] Update Jenkinsfile to docker-debian-jdk8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ def getVaultSecretsList() {
 
 common {
   slackChannel = '#connect-warn'
-  nodeLabel = 'docker-oraclejdk8'
+  nodeLabel = 'docker-debian-jdk8'
   publish = false
   downStreamValidate = false
   secret_file_list = getVaultSecretsList()


### PR DESCRIPTION
## Problem
docker-oraclejdk8 is an EOL debian 8 distribution that is deployed on the jenkins hosts but was removed in the [docker-build-images](https://github.com/confluentinc/confluent-docker-build-images/) repo. This makes supporting it very difficult, and one issue is the jenkins job fails to pull the latest common-tools version which is needed in the standard jenkins build logic. 

## Solution
Use the docker-debian-jdk8 node instead of docker-oraclejdk8. The images are very similar and this approach has worked before: 

https://github.com/confluentinc/kafka-connect-bigquerystorage-sink/pull/5
https://github.com/confluentinc/kafka-connect-sqs/pull/30


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
https://github.com/search?q=org%3Aconfluentinc+docker-oraclejdk8+NOT+is%3Aarchived&type=code

## Test Strategy
PR build works

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Merge to master and monitor the pipelines. This is relatively low risk since it only affects the jenkins agent so rollback is straightforward](https://github.com/search?q=org%3Aconfluentinc+docker-oraclejdk8+NOT+is%3Aarchived&type=code)