### PR TITLE
FF-12180: Updates README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ of [Apache Kafka Connect]. For a comprehensive list of configuration options, se
 
 ## Download
 
-The latest releases are available in the GitHub release tab, or via [tarballs in Maven central](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22kcbq-connector%22).
+The latest releases are available in the GitHub release tab, or via [Confluent Hub](https://www.confluent.io/hub/wepay/kafka-connect-bigquery).
 
 ## Standalone Quickstart
 


### PR DESCRIPTION
Updates Readme to add Confluent Hub as downloadable option and remove maven