### PR TITLE
Fix #349 retry on jobInternalError

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SleepUtils.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SleepUtils.java
@@ -4,7 +4,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class SleepUtils {
 
-    public static void waitRandomTime(int sleepMs, int jitterMs) throws InterruptedException {
-        Thread.sleep(sleepMs + ThreadLocalRandom.current().nextInt(jitterMs));
+    public static void waitRandomTime(long sleepMs, long jitterMs) throws InterruptedException {
+        Thread.sleep(sleepMs + ThreadLocalRandom.current().nextLong(jitterMs));
     }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryErrorResponses.java
@@ -44,6 +44,7 @@ public class BigQueryErrorResponses {
   private static final String BAD_REQUEST_REASON = "badRequest";
   private static final String INVALID_REASON = "invalid";
   private static final String INVALID_QUERY_REASON = "invalidQuery";
+  private static final String JOB_INTERNAL_ERROR = "jobInternalError";
   private static final String NOT_FOUND_REASON = "notFound";
   private static final String QUOTA_EXCEEDED_REASON = "quotaExceeded";
   private static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
@@ -82,6 +83,11 @@ public class BigQueryErrorResponses {
     return BAD_REQUEST_CODE == exception.getCode()
         && exception.getError() == null
         && exception.getReason() == null;
+  }
+
+  public static boolean isJobInternalError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+            && JOB_INTERNAL_ERROR.equals(exception.getReason());
   }
 
   public static boolean isQuotaExceededError(BigQueryException exception) {


### PR DESCRIPTION
This is a fix for #349 to retry when the error is a jobInternalError (400)

After contacting support this error should be rare and can happen during system overload 
The documentation mention this "Retry the job with a new jobId. If the error continues to occur, contact support."

So I reused the existing catch for the retriable serialization error, since this error happen during system overload it can be relevant to wait few seconds before retrying.

I am open to any suggestion.