### PR TITLE
Fix struct order for schema updates when using upsert/delete mode

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -49,8 +49,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -231,13 +233,23 @@ public class SchemaManager {
    * @return whether the table had to be created; if the table already existed, will return false
    */
   public boolean createTable(TableId table, List<SinkRecord> records) {
+    return createTable(table, records, null);
+  }
+
+  /**
+   * Create a new table in BigQuery.
+   * @param table The BigQuery table to create.
+   * @param records The sink records used to determine the schema.
+   * @return whether the table had to be created; if the table already existed, will return false
+   */
+  public boolean createTable(TableId table, List<SinkRecord> records, TableId parentTableId) {
     synchronized (lock(tableCreateLocks, table)) {
       if (schemaCache.containsKey(table)) {
         // Table already exists; noop
         logger.debug("Skipping create of {} as it should already exist or appear very soon", table(table));
         return false;
       }
-      TableInfo tableInfo = getTableInfo(table, records, true);
+      TableInfo tableInfo = getTableInfo(table, records, true, intermediateTables ? parentTableId : null);
       logger.info("Attempting to create {} with schema {}",
           table(table), tableInfo.getDefinition().getSchema());
       try {
@@ -263,7 +275,7 @@ public class SchemaManager {
    */
   public void updateSchema(TableId table, List<SinkRecord> records) {
     synchronized (lock(tableUpdateLocks, table)) {
-      TableInfo tableInfo = getTableInfo(table, records, false);
+      TableInfo tableInfo = getTableInfo(table, records, false, null);
       if (!schemaCache.containsKey(table)) {
         schemaCache.put(table, readTableSchema(table));
       }
@@ -287,11 +299,11 @@ public class SchemaManager {
    * @param createSchema Flag to determine if we are creating a new table schema or updating an existing table schema
    * @return The resulting BigQuery table information
    */
-  private TableInfo getTableInfo(TableId table, List<SinkRecord> records, Boolean createSchema) {
+  private TableInfo getTableInfo(TableId table, List<SinkRecord> records, Boolean createSchema, TableId parentTableId) {
     com.google.cloud.bigquery.Schema proposedSchema;
     String tableDescription;
     try {
-      proposedSchema = getAndValidateProposedSchema(table, records);
+      proposedSchema = getAndValidateProposedSchema(table, records, parentTableId);
       tableDescription = getUnionizedTableDescription(records);
     } catch (BigQueryConnectException exception) {
       throw new BigQueryConnectException("Failed to unionize schemas of records for the table " + table, exception);
@@ -299,12 +311,18 @@ public class SchemaManager {
     return constructTableInfo(table, proposedSchema, tableDescription, createSchema);
   }
 
+
   @VisibleForTesting
   com.google.cloud.bigquery.Schema getAndValidateProposedSchema(
       TableId table, List<SinkRecord> records) {
+    return getAndValidateProposedSchema(table, records, null);
+  }
+
+  com.google.cloud.bigquery.Schema getAndValidateProposedSchema(
+      TableId table, List<SinkRecord> records, TableId parentTable) {
     com.google.cloud.bigquery.Schema result;
     if (allowSchemaUnionization) {
-      List<com.google.cloud.bigquery.Schema> bigQuerySchemas = getSchemasList(table, records);
+      List<com.google.cloud.bigquery.Schema> bigQuerySchemas = getSchemasList(table, records, parentTable);
       result = getUnionizedSchema(bigQuerySchemas);
     } else {
       com.google.cloud.bigquery.Schema existingSchema = readTableSchema(table);
@@ -332,11 +350,23 @@ public class SchemaManager {
    * Returns a list of BigQuery schemas of the specified table and the sink records
    * @param table The BigQuery table's schema to add to the list of schemas
    * @param records The sink records' schemas to add to the list of schemas
+   * @param parentTable The Bigquery destination table's schema to merge into in case of an intermediate table
    * @return List of BigQuery schemas
    */
-  private List<com.google.cloud.bigquery.Schema> getSchemasList(TableId table, List<SinkRecord> records) {
+  private List<com.google.cloud.bigquery.Schema> getSchemasList(TableId table, List<SinkRecord> records, TableId parentTable) {
     List<com.google.cloud.bigquery.Schema> bigQuerySchemas = new ArrayList<>();
     Optional.ofNullable(readTableSchema(table)).ifPresent(bigQuerySchemas::add);
+    // We add the destination table schema (if it exists) in case of periodic MERGE flushes. This ensures the order
+    // of struct fields stays consistent under schema updates.
+    Optional.ofNullable(parentTable).map(this::readTableSchema).ifPresent(parentSchema -> {
+      com.google.cloud.bigquery.Schema parentSchemaWithoutKey = com.google.cloud.bigquery.Schema.of(
+        parentSchema.getFields().stream()
+          .filter(f -> !Arrays.asList(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG).contains(f.getName()))
+          .collect(Collectors.toList())
+      );
+      List<Field> schemaFields = getIntermediateSchemaFields(parentSchemaWithoutKey, schemaRetriever.retrieveKeySchema(records.get(0)));
+      bigQuerySchemas.add(com.google.cloud.bigquery.Schema.of(schemaFields));
+    });
     for (SinkRecord record : records) {
       Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
       if (kafkaValueSchema == null) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -160,8 +160,12 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
   }
 
   protected void attemptTableCreate(TableId tableId, List<SinkRecord> records) {
+    attemptTableCreate(tableId, records, null);
+  }
+
+  protected void attemptTableCreate(TableId tableId, List<SinkRecord> records, TableId parentTableId) {
     try {
-      schemaManager.createTable(tableId, records);
+      schemaManager.createTable(tableId, records, parentTableId);
     } catch (BigQueryException exception) {
       throw new BigQueryConnectException(
               "Failed to create table " + tableId, exception);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -73,8 +73,6 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
     try {
       // ... and update the destination table here
       schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), records);
-      // TODO Damit die Reihenfolge passt, hier eher sowas:
-      //schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), newIntermediateTableSchema);
     } catch (BigQueryException exception) {
       throw new BigQueryConnectException(
           "Failed to update destination table schema for: " + tableId.getBaseTableId(), exception);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -73,6 +73,8 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
     try {
       // ... and update the destination table here
       schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), records);
+      // TODO Damit die Reihenfolge passt, hier eher sowas:
+      //schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), newIntermediateTableSchema);
     } catch (BigQueryException exception) {
       throw new BigQueryConnectException(
           "Failed to update destination table schema for: " + tableId.getBaseTableId(), exception);
@@ -82,12 +84,13 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
   @Override
   protected void attemptTableCreate(TableId tableId, List<SinkRecord> records) {
     // Create the intermediate table here...
-    super.attemptTableCreate(tableId, records);
+    TableId parentTableId = intermediateToDestinationTables.get(tableId);
+    super.attemptTableCreate(tableId, records, parentTableId);
     if (autoCreateTables) {
       try {
         // ... and create or update the destination table here, if it doesn't already exist and auto
         // table creation is enabled
-        schemaManager.createOrUpdateTable(intermediateToDestinationTables.get(tableId), records);
+        schemaManager.createOrUpdateTable(parentTableId, records);
       } catch (BigQueryException exception) {
         throw new BigQueryConnectException(
             "Failed to create table " + tableId, exception);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -143,7 +143,7 @@ public class BigQueryWriterTest {
             Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
     testTask.flush(Collections.emptyMap());
 
-    verify(schemaManager, times(1)).createTable(anyObject(), anyObject());
+    verify(schemaManager, times(1)).createTable(anyObject(), anyObject(), anyObject());
     verify(bigQuery, times(2)).insertAll(anyObject());
   }
 


### PR DESCRIPTION
When using the connector in upsert/delete mode, it can fail under certain circumstances when the schema is updated in such a way that the intermediate table and the destination table have differently ordered nested struct fields.

## Example scenario

### Schema version 1

Assume the Kafka source topic has the following Avro schema (version 1):

```
{
   "type":"record",
   "name":"Message",
   "fields":[
      {
         "name":"data",
         "type":{
            "type":"record",
            "name":"Data",
            "fields":[
               {
                  "name":"minAmount",
                  "type":[
                     "null",
                     "int"
                  ],
                  "default":null
               },
               {
                  "name":"name",
                  "type":[
                     "null",
                     "string"
                  ],
                  "default":null
               }
            ]
         }
      }
   ]
}
```

The corresponding Bigquery destination table schema:

```
[  
  {
    "fields": [
      {
        "name": "minAmount",
        "type": "INTEGER"
      },
      {
        "name": "name",
        "type": "STRING"
      }
    ],
    "name": "data",
    "type": "RECORD"
  }
  // additional fields for Kafka key, Kafka data
]
```
### Schema version 2

Now, the source table schema is updated to version 2:

```
{
   "type":"record",
   "name":"Message",
   "fields":[
      {
         "name":"data",
         "type":{
            "type":"record",
            "name":"Data",
            "fields":[
               {
                  "name":"minAmount",
                  "type":[
                     "null",
                     "int"
                  ],
                  "default":null
               },
               {
                  "name":"maxAmount",
                  "type":[
                     "null",
                     "int"
                  ],
                  "default":null
               },
               {
                  "name":"name",
                  "type":[
                     "null",
                     "string"
                  ],
                  "default":null
               }
            ]
         }
      }
   ]
}
```

The problem now is that the Bigquery schemas of the intermediate and destination tables will have different orders of nested fields.

Bigquery schema of the intermediate table after creation:

```
[  
  {
    "fields": [
      {
        "name": "minAmount",
        "type": "INTEGER"
      },
      {
        "name": "maxAmount",
        "type": "INTEGER"
      },
      {
        "name": "name",
        "type": "STRING"
      },
    "name": "data",
    "type": "RECORD"
  }
  // additional fields for Kafka key, Kafka data
]
```

Updated Bigquery destination table schema - note that the new field `maxAmount` is appended at the end:

```
[  
  {
    "fields": [
      {
        "name": "minAmount",
        "type": "INTEGER"
      },
      {
        "name": "name",
        "type": "STRING"
      },
      {
        "name": "maxAmount",
        "type": "INTEGER"
      }
    ],
    "name": "data",
    "type": "RECORD"
  }
  // additional fields for Kafka key, Kafka data
]
```

The connector will subsequently fail during the periodic merge flush:

```
Value of type STRUCT<minAmount INT64, maxAmount INT64, name STRING> cannot be assigned to dstTableAlias.data, which has type STRUCT<minAmount INT64, name STRING, maxAmount INT64>
```

This can be easily seen by looking at the executed MERGE queries.

### Comparison of executed MERGE queries

This query will fail due to different orders of nested fields:

```
BEGIN
    CREATE TEMP TABLE _SESSION.destination AS (        
        select 'foo' as key, struct(1 as minAmount, 'v1' as name, null as maxAmount) as data
    );
    CREATE TEMP TABLE _SESSION.intermediate AS (        
        select 'foo' as key, struct(1 as minAmount, 10 as maxAmount, 'v2' as name) as data
    );
   
MERGE _SESSION.destination dstTableAlias 
USING _SESSION.intermediate src 
ON dstTableAlias.key=src.key 
WHEN MATCHED THEN UPDATE SET dstTableAlias.data=src.data
WHEN NOT MATCHED THEN INSERT (`key`,`data`) VALUES (src.key, src.data);

select * from _SESSION.destination;

END
```

In contrast, this query succeeds:

```
BEGIN
    CREATE TEMP TABLE _SESSION.destination AS (        
        select 'foo' as key, struct(1 as minAmount, 'v1' as name, null as maxAmount) as data
    );
    CREATE TEMP TABLE _SESSION.intermediate_reordered AS (
        select 'foo' as key, struct(1 as minAmount, 'v2' as name, 10 as maxAmount) as data
    );
   
MERGE _SESSION.destination dstTableAlias 
USING _SESSION.intermediate_reordered src 
ON dstTableAlias.key=src.key 
WHEN MATCHED THEN UPDATE SET dstTableAlias.data=src.data
WHEN NOT MATCHED THEN INSERT (`key`,`data`) VALUES (src.key, src.data);

select * from _SESSION.destination;

END
```

We can see that for upserts, the order of struct fields matters.

## Proposed changes

In this PR, I have added the destination table schema to the list returned by `SchemaManager.getSchemasList` when it is called for an intermediate table in upsert/merge mode. That way, the intermediate table schema is forced to respect the order of nested fields in the destination table schema - schema updates are simply applied on top of it, ensuring the same field order in both tables when new fields are added.

Please let me know what you think of this approach. 
