### PR TITLE
Fix failing build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
@@ -220,7 +219,6 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_${kafka.scala.version}</artifactId>
                 <version>${kafka.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
The scope of jackson dependency changed to **test** from 2.0.x onwards, due to which the build started failing corresponding to the new filtering changes.