### PR TITLE
Bumps Jackson dependency version to 2.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <google.cloud.version>1.79.0</google.cloud.version>
         <google.protobuf.version>3.19.6</google.protobuf.version>
         <gson.version>2.8.5</gson.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.16.2</jackson.version>
         <kafka.version>2.5.0</kafka.version>
         <slf4j.version>1.7.26</slf4j.version>
 
@@ -216,6 +216,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Bumps jackson core dependency to non-vulnerable version. 

```
bhagyashree@J6FQLC2XVG bigquery-storage-write-api % mvn dependency:tree  | grep jackson.core
[INFO]    |  |     \- com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
[INFO] |  |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile

```