### PR TITLE
Update Google Auth Library to enable WIF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <com.google.re2j.version>1.7</com.google.re2j.version>
         <confluent.version>6.0.10</confluent.version>
         <debezium.version>0.6.2</debezium.version>
-        <google.auth.version>0.21.1</google.auth.version>
+        <google.auth.version>0.24.0</google.auth.version>
         <google.cloud.version>2.10.9</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <google.protobuf.version>3.19.6</google.protobuf.version>


### PR DESCRIPTION
The Google Auth library started allowing the use of Workload Identity Federation in version 24.0, so we upgrade to that version ([Changelog](ServiceAccountJwtAccessCredentials)).

note that there is a single breaking change in [this commit](https://github.com/googleapis/google-auth-library-java/pull/473), but it is to privatize a deprecated constructor (`ServiceAccountJwtAccessCredentials`) that does not appear to be used in any of this repository's source code.