### PR TITLE
Removes data type validation check

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -385,10 +385,6 @@ public class SchemaManager {
     checkState(firstField.getName().equals(secondField.getName()),
             String.format("Cannot perform union operation on two fields having different names. " +
                     "Field names are '%s' and '%s'.", firstField.getName(), secondField.getName()));
-    checkState(firstField.getType() == secondField.getType(),
-            String.format("Cannot perform union operation on two fields having different datatypes. " +
-                    "Field name is '%s' and datatypes are '%s' and '%s'.", firstField.getName(), firstField.getType(), secondField.getType()));
-
     Field.Builder retBuilder = firstField.toBuilder();
     if (isFieldRelaxation(firstField, secondField)) {
       retBuilder.setMode(secondField.getMode());


### PR DESCRIPTION
This PR removes the datatype validation check as it is incorrect. This check will false report datatype mismatches when the existing table schema does not match with connector generated schema. 
For example: Imagine a BigQuery table exists with Schema : 
```
Field Name: "f1"
DatType: BigDecimal
```
There is an input of below format : 
`{"f1":123,"f2":"abc"}`
The connector is configured to autoUpdateSchema with 
```
  "allowNewBigQueryFields": "true",
  "allowBigQueryRequiredFieldRelaxation":"true",
  "allowSchemaUnionization":"true",
```
Due to `allowSchemaUnionization`, the connector would first fetch the existing table Schema and then would try to unionize the existing schema with the generated schema based on the input record 
```
Field Name: "f1"
DatType: Integer

Field Name: "f2"
DatType: String
```
The validation would fail here as Integer != BigDecimal. 
The expectation is unionize should give precedence to the existing table schema (as the connector only supports a limited datatypes and datatype change is not allowed as part of schema update) and only add new/relax fields when required.

Same example has been tested manually via CP.