### PR TITLE
[CONMON-4341] Update kafka.version to fix CVE on org.apache.kafka:kafka_2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <google.protobuf.version>3.19.6</google.protobuf.version>
         <jackson.version>2.16.2</jackson.version>
-        <kafka.version>2.6.0</kafka.version>
+        <kafka.version>2.6.3</kafka.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <slf4j.version>1.7.26</slf4j.version>
         <caffeine.version>2.8.6</caffeine.version>


### PR DESCRIPTION
Address CONMON CVE on kafka_2.12
```
docker export fedramp-image | tar tvf - | grep kafka_2.12
-rw-r--r--  0 65532  65532   4485205 Apr 14 20:55 usr/share/java/connectors/plugins/kafka-connect-bigquery-cloud/kafka_2.12-2.6.0.jar
```