### PR TITLE
replace twistlock scanning with trivy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,1 @@
+# See https://aquasecurity.github.io/trivy/v0.56/docs/configuration/filtering/#trivyignore for guidance on adding exceptions for Trivy scanner

--- a/service.yml
+++ b/service.yml
@@ -8,7 +8,7 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
-  cve_scan: true
+  trivy_scan: true
   extra_secrets:
     - kcbq_gcp
   extra_deploy_args: "-Pjenkins"


### PR DESCRIPTION

## Background
This PR is being created to enable trivy scanning for this repository by replacing the existing `cve_scan` and `run_maven_cve_scan` semaphore configurations with `trivy_scan`. 
This is part of a larger effort to improve Third party vulnerability (CVE) detection workflow for connectors by:
* letting developers verify the fixes for third party vulnerabilities at PR stage
* failing the pipeline if CRITICAL third-party vulnerabilities are found
* letting developers get a self-service exception for CRITICAL vulnerabilities using [.trivyignore file](https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#trivyignore)


🚨## Action needed🚨
Please approve and merge this change. Once you merge it, you will get another PR from service-bot to add trivy scanning to the pipeline.
**Please approve and merge BOTH PRs before November 11, 2024.** 
If status checks are failing, please debug as necessary. Contact #appsec slack channel for help.
