### PR TITLE
[cc-32905] Adding threadName pattern

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -27,6 +27,9 @@ import java.util.Map;
  * Class for task-specific configuration properties.
  */
 public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
+
+  private final int taskId;
+  private final String connectorName;
   
   public static final String GCS_BQ_TASK_CONFIG = "GCSBQTask";
   private static final ConfigDef.Type GCS_BQ_TASK_TYPE = ConfigDef.Type.BOOLEAN;
@@ -62,5 +65,15 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
    */
   public BigQuerySinkTaskConfig(Map<String, String> properties) {
     super(config(), properties);
+    taskId = getInt(TASK_ID_CONFIG);
+    connectorName = originalsStrings().get("name");
+  }
+
+  public int taskNumber() {
+    return taskId;
+  }
+
+  public String connectorName() {
+    return connectorName;
   }
 }


### PR DESCRIPTION
## Problem
Currently, threads in `BigQuerySinkTask` and `KCBQThreadPoolExecutor` are created using the default thread factory, which generates generic thread names. This makes it difficult to identify which connector task is executing in thread dumps, logs, or monitoring tools, especially when multiple tasks are running concurrently.

Jira: https://confluentinc.atlassian.net/browse/CC-32905

## Solution
 - This update enhances the BigQuery Sink Connector by introducing custom thread naming for executor threads. Key changes include:
 - Adding connector name and task ID to thread names for both ScheduledThreadPoolExecutor and KCBQThreadPoolExecutor.
- Incrementally numbering threads within a task for easier identification (<connectorName>-<taskId>-bigquery-writer-<n>).
- Updating BigQuerySinkTaskConfig to expose connectorName and taskNumber() for thread naming.
- By providing meaningful thread names, debugging thread-related issues, monitoring task execution, and analyzing thread dumps becomes significantly easier.

## Test Strategy
Testing done:
1. Unit tests to verify threads are created with the correct naming pattern.
2l. Manual validation by observing thread names in logs and thread dumps during connector execution.
3. Ensured no functional changes to connector behavior.

## Release Plan
This update is backward compatible and will be released to Confluent Cloud (CC) customers as part of the next BigQuery Sink Connector update.