### PR TITLE
Handle data loss when processing from multiple topics 

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -183,8 +183,9 @@ public class TableWriter implements Runnable {
     public Builder(BigQueryWriter writer, PartitionedTableId table, SinkRecordConverter recordConverter) {
       this.writer = writer;
       this.table = table;
-
-      this.rows = new TreeMap<>(Comparator.comparing(SinkRecord::kafkaPartition)
+      this.rows = new TreeMap<>(Comparator
+              .comparing(SinkRecord::topic)
+              .thenComparing(SinkRecord::kafkaPartition)
               .thenComparing(SinkRecord::kafkaOffset));
       this.recordConverter = recordConverter;
 


### PR DESCRIPTION
**Issue  :**
When consuming from multiple Kafka topics, the BigQuery Sink  is silently dropping records if different topics produce messages with the same partition and offset. This occurs because the comparator used in the internal TreeMap does not include the topic name, resulting in key collisions and record overwrites.

**Fix :**
Updated the comparator to include SinkRecord::topic in addition to partition and offset 

**Steps to reproduce:**

1. Create two Kafka topics with the same number of partitions (e.g., 2):
user_events
order_events
2. Configure the BigQuery Sink Connector to consume both topics:
`{
  "topics": "user_events,order_events",
  ...
}
`
3. Produce two records to Kafka with the same partition and offset from different topics manually.
  Topic: user_events   | Partition: 0 | Offset: 1 | Value: {"user": "alice"} 
  Topic: order_events  | Partition: 0 | Offset: 1 | Value: {"order": "123"}

4. Observe the behavior in BigQuery:
Only one of the two records appears.
The other record is silently dropped due to collision in the internal TreeMap.

