### PR TITLE
Fix Debezium logical converter for date to cover historical dates

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -31,6 +31,7 @@ import io.debezium.time.ZonedTimestamp;
 import org.apache.kafka.connect.data.Schema;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
@@ -50,6 +51,8 @@ public class DebeziumLogicalConverters {
     LogicalConverterRegistry.register(Timestamp.SCHEMA_NAME, new TimestampConverter());
   }
 
+  public static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
+
   private static final int MICROS_IN_SEC = 1000000;
   private static final int MICROS_IN_MILLI = 1000;
 
@@ -68,10 +71,8 @@ public class DebeziumLogicalConverters {
 
     @Override
     public String convert(Object kafkaConnectObject) {
-      Integer daysSinceEpoch = (Integer) kafkaConnectObject;
-      long msSinceEpoch = TimeUnit.DAYS.toMillis(daysSinceEpoch);
-      java.util.Date date = new java.util.Date(msSinceEpoch);
-      return getBQDateFormat().format(date);
+      LocalDate date = EPOCH.plusDays((int)kafkaConnectObject);
+      return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -71,7 +71,8 @@ public class DebeziumLogicalConverters {
 
     @Override
     public String convert(Object kafkaConnectObject) {
-      LocalDate date = EPOCH.plusDays((int)kafkaConnectObject);
+      int days = (Integer) kafkaConnectObject;
+      LocalDate date = EPOCH.plusDays(days);
       return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -19,6 +19,7 @@
 
 package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
+import static com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.EPOCH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -34,15 +35,89 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConve
 import org.apache.kafka.connect.data.Schema;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
 public class DebeziumLogicalConvertersTest {
 
-  //corresponds to March 1 2017, 22:20:38.808(123) UTC
-  //              (March 1 2017, 14:20:38.808(123)-8:00)
-  private static final Integer DAYS_TIMESTAMP = 17226;
   private static final Integer MILLI_TIMESTAMP_INT = 1488406838;
   private static final Long MILLI_TIMESTAMP = 1488406838808L;
   private static final Long MICRO_TIMESTAMP = 1488406838808123L;
+
+  private final String underTestDate;
+
+  @Parameterized.Parameters
+  public static Collection<String> data() {
+    return Arrays.asList(
+            "0100-02-28",
+            "0100-03-01",
+            "0200-02-28",
+            "0200-03-01",
+            "0300-02-28",
+            "0300-03-01",
+            "0400-02-28",
+            "0400-02-29",
+            "0400-03-01",
+            "0500-02-28",
+            "0500-03-01",
+            "0600-02-28",
+            "0600-03-01",
+            "0700-02-28",
+            "0700-03-01",
+            "0800-02-28",
+            "0800-02-29",
+            "0800-03-01",
+            "0900-02-28",
+            "0900-03-01",
+            "1000-02-28",
+            "1000-03-01",
+            "1100-02-28",
+            "1100-03-01",
+            "1200-02-28",
+            "1200-02-29",
+            "1200-03-01",
+            "1300-02-28",
+            "1300-03-01",
+            "1400-02-28",
+            "1400-03-01",
+            "1500-02-28",
+            "1500-03-01",
+            "1582-10-01",
+            "1582-10-02",
+            "1582-10-03",
+            "1582-10-04",
+            "1582-10-15",
+            "1582-10-16",
+            "1582-10-17",
+            "1582-10-18",
+            "1582-10-19",
+            "1582-10-20",
+            "1582-10-21",
+            "1582-10-22",
+            "1582-10-23",
+            "1582-10-24",
+            "1582-10-25",
+            "1582-10-26",
+            "1582-10-27",
+            "1582-10-28",
+            "1582-10-29",
+            "1582-10-30",
+            "1582-10-31",
+
+            "2017-03-01"
+    );
+  }
+
+  public DebeziumLogicalConvertersTest(String underTestDate) {
+    this.underTestDate = underTestDate;
+  }
 
   @Test
   public void testDateConversion() {
@@ -55,9 +130,11 @@ public class DebeziumLogicalConvertersTest {
     } catch (Exception ex) {
       fail("Expected encoding type check to succeed.");
     }
-    
-    String formattedDate = converter.convert(DAYS_TIMESTAMP);
-    assertEquals("2017-03-01", formattedDate);
+
+    int epochDays = convertDateToNumberOfDaysPassedFromEpoch(underTestDate);
+
+    String formattedDate = converter.convert(epochDays);
+    assertEquals(underTestDate, formattedDate);
   }
 
   @Test
@@ -154,4 +231,11 @@ public class DebeziumLogicalConvertersTest {
     String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
     assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
   }
+
+  private int convertDateToNumberOfDaysPassedFromEpoch(String underTestDate) {
+    // This is similar to conversion that happens in Debezium. For any date before 1970-01-01 the number of day is negative
+    LocalDate date = LocalDate.parse(underTestDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    return (int) ChronoUnit.DAYS.between(EPOCH, date);
+  }
+
 }


### PR DESCRIPTION

By default, Postgres Debezium uses [adaptive mode](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-time-precision-mode-adaptive) for handling date fields. In this mode, any date type is encoded as an `Int32` representing the number of days since the Unix epoch. Dates before the epoch are represented as negative numbers. When Debezium sends an integer-encoded date, the BigQuery connector converts it to a string representation. However, this conversion can fail for certain historical dates before `1582`, when the calendar changed from Julian to Gregorian. For example, the date `1500-03-10` is encoded as `-171596`, but BigQuery converts it to `1500-02-29`, which is not a valid date, causing BigQuery to reject the record and send it to the DLQ (if configured). Another example is`1582-10-01`, which is encoded as `-141441` by Debezium but shown as `1582-09-21` by the BigQuery connector.
