### PR TITLE
CVE fixes: Upgrade jackson-core, debezium-core, commons-beanutils, jose4j

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,7 +26,7 @@ global_job_config:
       - checkout
       - . vault-setup
       - . vault-sem-get-secret kcbq_gcp
-      - sem-version java 8
+      - sem-version java 11
       - . cache-maven restore
 
 blocks:

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </modules>
 
     <properties>
-        <java.version>8</java.version>
+        <java.version>11</java.version>
         <com.google.guava.version>32.0.1-jre</com.google.guava.version>
         <com.google.re2j.version>1.7</com.google.re2j.version>
         <confluent.version>7.9.5</confluent.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
         <com.google.guava.version>32.0.1-jre</com.google.guava.version>
         <com.google.re2j.version>1.7</com.google.re2j.version>
         <confluent.version>7.9.5</confluent.version>
-        <debezium.version>0.6.2</debezium.version>
+        <debezium.version>2.3.0.Alpha1</debezium.version>
         <google.auth.version>0.21.1</google.auth.version>
         <google.cloud.version>2.10.9</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <google.protobuf.version>3.25.5</google.protobuf.version>
-        <jackson.version>2.16.2</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <kafka.version>3.9.1</kafka.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <slf4j.version>1.7.26</slf4j.version>
@@ -305,6 +305,16 @@
                 <groupId>com.google.re2j</groupId>
                 <artifactId>re2j</artifactId>
                 <version>${com.google.re2j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>0.9.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

- Upgrade vulnerable dependencies to CVE-fixed versions
- Bump Java target from 8 to 11 (required by debezium-core 2.3.0.Alpha1)
- Update Semaphore CI to use Java 11

## Dependency Changes

| JIRA | Dependency | Before | After |
|------|-----------|--------|-------|
| [CC-39722](https://confluentinc.atlassian.net/browse/CC-39722) | `com.fasterxml.jackson.core:jackson-core` | 2.16.2 | **2.18.6** |
| [CC-39721](https://confluentinc.atlassian.net/browse/CC-39721) | `commons-beanutils:commons-beanutils` | 1.9.4 (transitive) | **1.11.0** |
| [CC-39720](https://confluentinc.atlassian.net/browse/CC-39720) | `io.debezium:debezium-core` | 0.6.2 | **2.3.0.Alpha1** |
| [CC-39719](https://confluentinc.atlassian.net/browse/CC-39719) | `org.bitbucket.b_c:jose4j` | 0.9.4 (transitive) | **0.9.6** |

## Changes

- `pom.xml`: Update `jackson.version` from `2.16.2` to `2.18.6`
- `pom.xml`: Update `debezium.version` from `0.6.2` to `2.3.0.Alpha1`
- `pom.xml`: Add `commons-beanutils:1.11.0` and `jose4j:0.9.6` to `<dependencyManagement>` to pin transitive dependency versions
- `pom.xml`: Update `java.version` from `8` to `11` (required by debezium-core 2.3.0.Alpha1)
- `.semaphore/semaphore.yml`: Update `sem-version java 8` to `sem-version java 11`

## Verification

- [x] Unit tests pass (209 tests, 0 failures)
- [x] Dependency tree confirms all 4 vulnerable versions are resolved to fixed versions
- [x] KDP BigQuery sink test passes on CP 8.1.0
- [x] KDP BigQuery sink test passes on CP 8.2.0

## Related JIRAs

- [CC-39722](https://confluentinc.atlassian.net/browse/CC-39722) — jackson-core:2.16.2
- [CC-39721](https://confluentinc.atlassian.net/browse/CC-39721) — commons-beanutils:1.9.4
- [CC-39720](https://confluentinc.atlassian.net/browse/CC-39720) — debezium-core:0.6.2
- [CC-39719](https://confluentinc.atlassian.net/browse/CC-39719) — jose4j:0.9.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-39722]: https://confluentinc.atlassian.net/browse/CC-39722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-39721]: https://confluentinc.atlassian.net/browse/CC-39721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-39720]: https://confluentinc.atlassian.net/browse/CC-39720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-39719]: https://confluentinc.atlassian.net/browse/CC-39719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-39722]: https://confluentinc.atlassian.net/browse/CC-39722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ