### PR TITLE
Added the quota exceeded error as retryable error during mergeflush

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -173,6 +173,8 @@ public class MergeQueries {
             logger.warn("Serialize access error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
           } else if (BigQueryErrorResponses.isJobInternalError(e)) {
             logger.warn("Job internal error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
+          } else if (BigQueryErrorResponses.isQuotaExceededError(e)) {
+            logger.warn("Quota exceeded error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
           } else {
             throw e;
           }


### PR DESCRIPTION
Fixes #481 
When a quota exceeded error occurs during a merge flush, the current code rethrows it immediately without retrying, leaving the failed batch permanently in the internal batches map. This causes all subsequent flush attempts to block indefinitely inside prepareToFlush waiting for the stuck batch to be removed, making the connector silently stop delivering data even after the quota resets.
This PR adds quota exceeded as a retryable error in the merge flush retry logic alongside the existing serialize access and job internal errors. Configuring bigQueryRetry and bigQueryRetryWait such that the total retry window exceeds 24 hours allows the flush to succeed naturally once the quota resets, without any task failure or data loss.