### PR TITLE
feat: add universe_domain support

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
@@ -62,11 +62,13 @@ public abstract class GcpClientBuilder<Client> {
       URI.create("https://oauth2.googleapis.com/token");
   private HeaderProvider headerProvider = null;
   private String project = null;
+  private String universeDomain = null;
   private KeySource keySource = null;
   private String key = null;
 
   public GcpClientBuilder<Client> withConfig(BigQuerySinkConfig config) {
     return withProject(config.getString(PROJECT_CONFIG))
+        .withUniverseDomain(config.getUniverseDomain())
         .withKeySource(config.getKeySource())
         .withKey(config.getKey())
         .withUserAgent(config.getString(CONNECTOR_RUNTIME_PROVIDER_CONFIG));
@@ -75,6 +77,11 @@ public abstract class GcpClientBuilder<Client> {
   public GcpClientBuilder<Client> withProject(String project) {
     Objects.requireNonNull(project, "Project cannot be null");
     this.project = project;
+    return this;
+  }
+
+  public GcpClientBuilder<Client> withUniverseDomain(String universeDomain) {
+    this.universeDomain = universeDomain;
     return this;
   }
 
@@ -101,7 +108,7 @@ public abstract class GcpClientBuilder<Client> {
   }
 
   public Client build() {
-    return doBuild(project, credentials(), headerProvider);
+    return doBuild(project, universeDomain, credentials(), headerProvider);
   }
 
   private GoogleCredentials credentials() {
@@ -153,14 +160,18 @@ public abstract class GcpClientBuilder<Client> {
         .build();
   }
 
-  protected abstract Client doBuild(String project, GoogleCredentials credentials, HeaderProvider userAgent);
+  protected abstract Client doBuild(String project, String universeDomain, GoogleCredentials credentials, HeaderProvider userAgent);
 
   public static class BigQueryBuilder extends GcpClientBuilder<BigQuery> {
     @Override
-    protected BigQuery doBuild(String project, GoogleCredentials credentials, HeaderProvider headerProvider) {
+    protected BigQuery doBuild(String project, String universeDomain, GoogleCredentials credentials, HeaderProvider headerProvider) {
       BigQueryOptions.Builder builder = BigQueryOptions.newBuilder()
           .setProjectId(project)
           .setHeaderProvider(headerProvider);
+
+      if (universeDomain != null && !universeDomain.isEmpty()) {
+        builder.setUniverseDomain(universeDomain);
+      }
 
       if (credentials != null) {
         builder.setCredentials(credentials);
@@ -174,10 +185,14 @@ public abstract class GcpClientBuilder<Client> {
 
   public static class GcsBuilder extends GcpClientBuilder<Storage> {
     @Override
-    protected Storage doBuild(String project, GoogleCredentials credentials, HeaderProvider headerProvider) {
+    protected Storage doBuild(String project, String universeDomain, GoogleCredentials credentials, HeaderProvider headerProvider) {
       StorageOptions.Builder builder = StorageOptions.newBuilder()
           .setProjectId(project)
           .setHeaderProvider(headerProvider);
+
+      if (universeDomain != null && !universeDomain.isEmpty()) {
+        builder.setUniverseDomain(universeDomain);
+      }
 
       if (credentials != null) {
         builder.setCredentials(credentials);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -112,6 +112,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String PROJECT_DOC =
       "The BigQuery project to write to";
 
+  public static final String UNIVERSE_DOMAIN_CONFIG = "universe_domain";
+  private static final ConfigDef.Type UNIVERSE_DOMAIN_TYPE = ConfigDef.Type.STRING;
+  private static final Object UNIVERSE_DOMAIN_DEFAULT = null;
+  private static final ConfigDef.Importance UNIVERSE_DOMAIN_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String UNIVERSE_DOMAIN_DOC =
+      "The universe domain of the BigQuery environment. Can also be set via GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable.";
+
   public static final String DEFAULT_DATASET_CONFIG =             "defaultDataset";
   private static final ConfigDef.Type DEFAULT_DATASET_TYPE =       ConfigDef.Type.STRING;
   private static final Object DEFAULT_DATASET_DEFAULT =             ConfigDef.NO_DEFAULT_VALUE;
@@ -598,6 +605,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             PROJECT_IMPORTANCE,
             PROJECT_DOC
         ).define(
+            UNIVERSE_DOMAIN_CONFIG,
+            UNIVERSE_DOMAIN_TYPE,
+            UNIVERSE_DOMAIN_DEFAULT,
+            UNIVERSE_DOMAIN_IMPORTANCE,
+            UNIVERSE_DOMAIN_DOC
+        ).define(
             DEFAULT_DATASET_CONFIG,
             DEFAULT_DATASET_TYPE,
             DEFAULT_DATASET_DEFAULT,
@@ -899,6 +912,17 @@ public class BigQuerySinkConfig extends AbstractConfig {
    */
   public String getKey() {
     return Optional.ofNullable(getPassword(KEYFILE_CONFIG)).map(Password::value).orElse(null);
+  }
+
+  /**
+   * @return the universe domain, fetched from config or environment variable
+   */
+  public String getUniverseDomain() {
+    String universeDomain = getString(UNIVERSE_DOMAIN_CONFIG);
+    if (universeDomain == null || universeDomain.isEmpty()) {
+      universeDomain = System.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN");
+    }
+    return universeDomain;
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderTest.java
@@ -48,7 +48,7 @@ public class GcpClientBuilderTest {
    */
   private static class CapturingBuilder extends GcpClientBuilder<GoogleCredentials> {
     @Override
-    protected GoogleCredentials doBuild(String project, GoogleCredentials credentials,
+    protected GoogleCredentials doBuild(String project, String universeDomain, GoogleCredentials credentials,
                                         HeaderProvider userAgent) {
       return credentials;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         <com.google.re2j.version>1.7</com.google.re2j.version>
         <confluent.version>7.9.5</confluent.version>
         <debezium.version>2.3.0.Alpha1</debezium.version>
-        <google.auth.version>0.21.1</google.auth.version>
-        <google.cloud.version>2.10.9</google.cloud.version>
-        <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
+        <google.auth.version>1.48.0</google.auth.version>
+        <google.cloud.version>2.47.0</google.cloud.version>
+        <google.cloud.storage.version>2.43.0</google.cloud.storage.version>
         <google.protobuf.version>3.25.5</google.protobuf.version>
         <jackson.version>2.18.6</jackson.version>
         <kafka.version>3.9.1</kafka.version>


### PR DESCRIPTION
## Description
This PR adds support for specifying a Google Cloud `universe_domain` within the Kafka Connect BigQuery connector. This allows the connector to operate in diverse Google Cloud environments, such as those using Google Distributed Cloud (GDC).

The universe domain can be configured in two ways:
    1. Setting the `universe_domain` configuration property in the connector configuration.
    2. Using the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable (the connector will fall back to this if the config property is omitted).

In order to leverage the Universe Domain APIs in the GCP builders, this PR also updates the Google Cloud and Auth Java client dependencies to more recent versions.

## Changes

  * **Config:** Added the `universe_domain` property to `BigQuerySinkConfig` and logic to resolve it, falling back to the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable.
  * **Clients:** Plumbed the `universeDomain` parameter through `GcpClientBuilder` to properly set it on `BigQueryOptions` and `StorageOptions` builders.
  * **Dependencies:** Bumped versions in `pom.xml` to gain access to the `setUniverseDomain` methods:
    * `google.auth.version`: 0.21.1 -> 1.48.0
    * `google.cloud.version`: 2.10.9 -> 2.47.0
    * `google.cloud.storage.version`: 1.113.4 -> 2.43.0
  * **Tests:** Updated `GcpClientBuilderTest` to accommodate the updated `doBuild` method signature.