### PR TITLE
CC-42346: bump jackson to 2.21.5 to fix jackson-databind CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <google.cloud.version>2.10.9</google.cloud.version>
         <google.cloud.storage.version>1.113.4</google.cloud.storage.version>
         <google.protobuf.version>3.25.5</google.protobuf.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <kafka.version>3.9.1</kafka.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
## Summary

Fixes four `com.fasterxml.jackson.core:jackson-databind` CVEs flagged on the 2.5.x branch by bumping `jackson.version` **2.18.6 → 2.21.5** (the property drives both `jackson-core` and `jackson-databind`).

| JIRA | CVE | Issue |
|------|-----|-------|
| [CVE-21295](https://confluentinc.atlassian.net/browse/CVE-21295) | CVE-2026-54512 | PTV generic-parameter allowlist bypass |
| [CVE-21297](https://confluentinc.atlassian.net/browse/CVE-21297) | CVE-2026-54513 | PTV array component-type allowlist bypass |
| [CVE-21299](https://confluentinc.atlassian.net/browse/CVE-21299) | CVE-2026-54514 | `InetSocketAddress` eager DNS resolution at deserialization |
| [CVE-21302](https://confluentinc.atlassian.net/browse/CVE-21302) | CVE-2026-54515 | `@JsonIgnoreProperties` case-insensitivity bypass |

Master vuln ticket: [CC-42346](https://confluentinc.atlassian.net/browse/CC-42346).

## Why 2.21.5 (and not 2.18.9 / 3.1.4)

- **2.18.9** — the value CC-42346 lists for CVE-21302 — was **never published**. The public 2.18.x line ends at **2.18.8**, which fixes the other three but **not** CVE-21302.
- **3.1.4** fixes all four but is a **breaking major**: Jackson 3 moved to the `tools.jackson` groupId/namespace (`com.fasterxml.jackson.core:jackson-databind:3.1.4` = 404; `tools.jackson.core:jackson-databind:3.1.4` = 200) and raises the JDK baseline. The surrounding stack (Kafka Connect runtime, Confluent serdes, Google BigQuery client, Debezium) is all Jackson 2.x, so mixing would break at runtime.
- **2.21.5** is the lowest publicly-available **Jackson 2.x** version fixing **all four** (2.21.5 covers CVE-21302). Same groupId/namespace → backward-compatible, minimal risk.

## Changes

- `pom.xml`: `jackson.version` `2.18.6` → `2.21.5`

Resolves to: `jackson-core:2.21.5`, `jackson-databind:2.21.5`, `jackson-annotations:2.21` (transitive). No other jackson modules are pinned by this project; the pre-existing transitive `jackson-datatype-*/dataformat-*` modules are unchanged and remain older than databind (the safe compatibility direction).

## Verification

- [x] `dependency:tree` confirms `jackson-databind` resolves to **2.21.5**; shipped hub zip bundles `jackson-databind-2.21.5.jar` / `jackson-core-2.21.5.jar`
- [x] Unit tests: **210 run, 0 failures, 0 errors**
- [x] KDP `connect-gcp-bigquery-sink` test (locally-built zip via `--connector-zip`) — **SUCCESS** on **CP 8.1.0**
- [x] KDP `connect-gcp-bigquery-sink` test — **SUCCESS** on **CP 8.2.0**
- [x] KDP `connect-gcp-bigquery-sink` test — **SUCCESS** on **CP 8.3.0**

(All three KDP runs wrote Avro records through the connector into BigQuery and passed the data-verification query.)

## Related JIRAs

- [CVE-21295](https://confluentinc.atlassian.net/browse/CVE-21295) — CVE-2026-54512 | kafka-connect-bigquery:2.5.10 | jackson-databind
- [CVE-21297](https://confluentinc.atlassian.net/browse/CVE-21297) — CVE-2026-54513 | kafka-connect-bigquery:2.5.10 | jackson-databind
- [CVE-21299](https://confluentinc.atlassian.net/browse/CVE-21299) — CVE-2026-54514 | kafka-connect-bigquery:2.5.10 | jackson-databind
- [CVE-21302](https://confluentinc.atlassian.net/browse/CVE-21302) — CVE-2026-54515 | kafka-connect-bigquery:2.5.10 | jackson-databind
- [CC-42346](https://confluentinc.atlassian.net/browse/CC-42346) — master vuln ticket | jackson-databind:2.18.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CVE-21295]: https://confluentinc.atlassian.net/browse/CVE-21295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-21297]: https://confluentinc.atlassian.net/browse/CVE-21297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-21299]: https://confluentinc.atlassian.net/browse/CVE-21299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-21302]: https://confluentinc.atlassian.net/browse/CVE-21302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-42346]: https://confluentinc.atlassian.net/browse/CC-42346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
