### PR TITLE
Migrate vault fetch from v1 to v3

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,8 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-setup
-      - . vault-sem-get-secret kcbq_gcp
+      - . vault-get-secret kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-get-secret kcbq_gcp
+      - . vault-get-secret connect/kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 


### PR DESCRIPTION
## Summary
- Migrate Semaphore CI vault fetching from v1 (`vault-setup` + `vault-sem-get-secret`) to v3 (`vault-get-secret`)