### PR TITLE
Migrate vault fetch from v1 to v3

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,8 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-setup
-      - . vault-sem-get-secret kcbq_gcp
+      - . vault-get-secret kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,10 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-get-secret connect/kcbq_gcp
+      - export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json
+      - . vault-get-secret connect/kcbq_gcp --secret-key=GOOGLE_APPLICATION_CREDENTIALS --save-as=GOOGLE_APPLICATION_CREDENTIALS
+      - export KCBQ_TEST_KEYFILE=/tmp/kcbq-test-keyfile.json
+      - . vault-get-secret connect/kcbq_gcp --secret-key=KCBQ_TEST_KEYFILE --save-as=KCBQ_TEST_KEYFILE
       - sem-version java 11
       - . cache-maven restore
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,9 +25,9 @@ global_job_config:
     commands:
       - checkout
       - export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json
-      - . vault-get-secret connect/kcbq_gcp --secret-key=GOOGLE_APPLICATION_CREDENTIALS --save-as=GOOGLE_APPLICATION_CREDENTIALS
+      - . vault-get-secret connect/kcbq_gcp --secret-key=GOOGLE_APPLICATION_CREDENTIALS --save-as=$GOOGLE_APPLICATION_CREDENTIALS
       - export KCBQ_TEST_KEYFILE=/tmp/kcbq-test-keyfile.json
-      - . vault-get-secret connect/kcbq_gcp --secret-key=KCBQ_TEST_KEYFILE --save-as=KCBQ_TEST_KEYFILE
+      - . vault-get-secret connect/kcbq_gcp --secret-key=KCBQ_TEST_KEYFILE --save-as=$KCBQ_TEST_KEYFILE
       - sem-version java 11
       - . cache-maven restore
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-get-secret kcbq_gcp
+      - . vault-get-secret connect/kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 


### PR DESCRIPTION
## Summary
- Backport of #486: migrate Semaphore CI vault fetching from v1 (`vault-setup` + `vault-sem-get-secret`) to v3 (`vault-get-secret`) for the 2.5.x branch