### PR TITLE
Fix vault v3 secret path for kcbq_gcp (connect/ prefix)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,9 +37,12 @@ blocks:
       prologue:
         commands:
           # Vault v3: fetch the GCP keyfile secret and write it to a file (no
-          # key content is printed); integration tests read it as a file path.
+          # key content is printed). KCBQ_TEST_KEYFILE is read as a file path by
+          # the FILE/JSON key-source tests; GOOGLE_APPLICATION_CREDENTIALS points
+          # at the same file for the APPLICATION_DEFAULT credentials test.
           - . vault-get-secret connect/kcbq_gcp --secret-key KCBQ_TEST_KEYFILE --save-as /tmp/kcbq_gcp_keyfile.json
           - export KCBQ_TEST_KEYFILE=/tmp/kcbq_gcp_keyfile.json
+          - export GOOGLE_APPLICATION_CREDENTIALS=/tmp/kcbq_gcp_keyfile.json
       jobs:
         - name: Test
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,8 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-setup
-      - . vault-sem-get-secret kcbq_gcp
+      - . vault-get-secret kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - . vault-get-secret kcbq_gcp
       - sem-version java 11
       - . cache-maven restore
 
@@ -35,6 +34,12 @@ blocks:
       # don't run the tests on non-functional changes...
       when: "change_in('/', {exclude: ['/.deployed-versions/', '.github/'], default_branch: 'master'})"
     task:
+      prologue:
+        commands:
+          # Vault v3: fetch the GCP keyfile secret and write it to a file (no
+          # key content is printed); integration tests read it as a file path.
+          - . vault-get-secret connect/kcbq_gcp --secret-key KCBQ_TEST_KEYFILE --save-as /tmp/kcbq_gcp_keyfile.json
+          - export KCBQ_TEST_KEYFILE=/tmp/kcbq_gcp_keyfile.json
       jobs:
         - name: Test
           commands:

--- a/service.yml
+++ b/service.yml
@@ -8,8 +8,6 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
-  extra_secrets:
-  - kcbq_gcp
   extra_deploy_args: "-Pjenkins"
   extra_build_args: "-Pjenkins"
   generate_connect_changelogs: true


### PR DESCRIPTION
## Summary

Builds on **#487** (vault v1→v3 migration) and fixes **two** issues so the integration tests can run on 2.5.x:

1. **Secret path** — `vault-get-secret kcbq_gcp` resolved to `semaphore/kcbq_gcp` → *permission denied*. Confluent CI secrets live under the `connect/` namespace, so the correct call is `vault-get-secret connect/kcbq_gcp` (matches org-wide usage: `connect/connect_bq`, `connect/connect_s3sink_it`, …).

2. **Keyfile must be a file** — v3 `vault-get-secret` exports `KCBQ_TEST_KEYFILE` as the raw keyfile **JSON content**, but the integration tests use it as a **file path** (`keySource=FILE`; `GcpClientBuilderIT` does `Paths.get(keyFile())`). That made all 22 ITs fail with `Failed to access credentials file / FileNotFoundException: <json> (File name too long)`. Fix: write the content to a file and repoint the env var (restores what the v1 `vault-sem-get-secret` helper did).

```diff
-      - . vault-setup
-      - . vault-sem-get-secret kcbq_gcp
+      - . vault-get-secret connect/kcbq_gcp
+      - printf '%s' "$KCBQ_TEST_KEYFILE" > /tmp/kcbq_gcp_keyfile.json
+      - export KCBQ_TEST_KEYFILE=/tmp/kcbq_gcp_keyfile.json
```

## Notes

- Branched from `ashfaq/migrate-vault-v3-2.5.x` (#487) per request; can be merged in place of it.
- **Security:** before this fix, the keyfile content was landing in CI logs via the exception message (full SA private key printed). The SA `bigquery-sink-integration-test@connect-205118` should be **rotated**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
