### PR TITLE
CC-42851: Redact BigQuery per-row error message from insert failure logs

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -53,11 +53,10 @@ public class BigQueryConnectException extends ConnectException {
     for (Map.Entry<Long, List<BigQueryError>> errorsEntry : errorsMap.entrySet()) {
       for (BigQueryError error : errorsEntry.getValue()) {
         messageBuilder.append(String.format(
-            "%n\t[row index %d] (location %s, reason: %s): %s",
+            "%n\t[row index %d] (location %s, reason: %s)",
             errorsEntry.getKey(),
             error.getLocation(),
-            error.getReason(),
-            error.getMessage()
+            error.getReason()
         ));
       }
     }


### PR DESCRIPTION
## Problem
[CC-42851](https://confluentinc.atlassian.net/browse/CC-42851) (linked to prod incident INC-12079).

`BigQueryConnectException.formatInsertAllErrors` appended `BigQueryError.getMessage()` verbatim. BigQuery's per-row error text embeds the **raw rejected record value**. The exception is logged at ERROR by the framework `LogReporter` (and handed to the DLQ `ErrantRecordReporter`), so Kafka record field contents leak into connect logs.

OpenSearch verification in the JIRA: 317M+ ERROR-level hits over 30 days for `"insertion failed for the following rows"`, content confirmed sensitive (e.g. `reason: invalid): Timestamp field value is out of range: <record value>`).

## Fix
Drop the free-form `error.getMessage()` — the only part that can carry record values — and keep the safe diagnostic fields: table info, `row index`, `location` (field name), `reason` (error code).

This single change closes all three leak paths from the JIRA (`BigQueryWriter.java:139`, `:143`, `:247`), since they all construct the exception through the same constructor.

## Testing
- New `BigQueryConnectExceptionTest` asserts the formatted message retains the safe fields but excludes both the free-form message and the sensitive record value.
- Existing `BigQueryWriterTest` still passes (its assertion that the message contains the table/topic name is unaffected).
- `mvn -pl kcbq-connector test -Dtest=BigQueryConnectExceptionTest,BigQueryWriterTest` → 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CC-42851]: https://confluentinc.atlassian.net/browse/CC-42851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ